### PR TITLE
Update api-register-agent.ps1

### DIFF
--- a/examples/api-register-agent.ps1
+++ b/examples/api-register-agent.ps1
@@ -51,14 +51,13 @@ Ignore-SelfSignedCerts
 # Test API integration to make sure IE has run through initial startup dialogue - This can be a problem with new servers.
 
 try{
-$testresponse = req -method "GET" -resource "/manager/info?pretty" | ConvertFrom-Json | select -expand data -ErrorAction Stop -ErrorVariable geterr
+    $testresponse = req -method "GET" -resource "/manager/info?pretty" | ConvertFrom-Json | select -expand data -ErrorAction Stop -ErrorVariable geterr
 
-Write-Output "The Wazuh manager is contactable via the API, the response is: `n $($testresponse)"
-}
-catch{
-Write-Host -ForegroundColor Red "IE has not had it's initial startup dialogue dismissed, please complete this step and try again. Script will exit. Error: $($geterr)`n .Please Run OSSEC_AgentConfig Seperately once you correct the error."
-Exit
-}
+    Write-Output "The Wazuh manager is contactable via the API, the response is: `n $($testresponse)"
+    }catch{
+    Write-Host -ForegroundColor Red "IE has not had it's initial startup dialogue dismissed, please complete this step and try again. Script will exit. Error: $($geterr)`n .Please Run OSSEC_AgentConfig Seperately once you correct the error."
+    Exit
+    }
 
 # Test for agent already existing in manager
 

--- a/examples/api-register-agent.ps1
+++ b/examples/api-register-agent.ps1
@@ -1,3 +1,4 @@
+
 ###
 #  Powershell script for registering agents automatically with the API
 #  Copyright (C) 2017 Wazuh, Inc. All rights reserved.
@@ -13,7 +14,6 @@ function Ignore-SelfSignedCerts {
     add-type @"
         using System.Net;
         using System.Security.Cryptography.X509Certificates;
-
         public class PolicyCert : ICertificatePolicy {
             public PolicyCert() {}
             public bool CheckValidationResult(
@@ -39,12 +39,38 @@ function req($method, $resource, $params){
 }
 
 # Configuration
-$base_url = "http://10.0.0.1:55000"
+$base_url = "http://<Wazuh-Manager-IP>:55000"
 $username = "foo"
 $password = "bar"
 $agent_name = $env:computername
 $path = "C:\Program Files (x86)\ossec-agent\"
+$config = "C:\Program Files (x86)\ossec-agent\ossec.conf"
+$wazuh_manager = "<Wazuh-Manager-IP>"
 Ignore-SelfSignedCerts
+
+# Test API integration to make sure IE has run through initial startup dialogue - This can be a problem with new servers.
+
+try{
+$testresponse = req -method "GET" -resource "/manager/info?pretty" | ConvertFrom-Json | select -expand data -ErrorAction Stop -ErrorVariable geterr
+
+Write-Output "The Wazuh manager is contactable via the API, the response is: `n $($testresponse)"
+}
+catch{
+Write-Host -ForegroundColor Red "IE has not had it's initial startup dialogue dismissed, please complete this step and try again. Script will exit. Error: $($geterr)`n .Please Run OSSEC_AgentConfig Seperately once you correct the error."
+Exit
+}
+
+# Test for agent already existing in manager
+
+$agentexist = req -method "GET" -resource "/agents?pretty" -params @{search=$agent_name} # searches for the agent based on the env variable name
+
+$agentinfo = $agentexist.Content | ConvertFrom-Json | select -expand data | select totalitems
+
+$agentexistid = $agentexist.Content | ConvertFrom-Json | select -expand data | select -expand items | select id # expands the embedded JSON items to retrieve the agent ID
+
+# If agent does not already exist proceed to create agent and register the agent key
+
+if ($agentinfo.totalitems -lt 1){
 
 # Adding agent and getting Id from manager
 
@@ -83,7 +109,46 @@ Stop-Service $srvName
 $srvStat = Get-Service $srvName
 Write-Output "$($srvName) is now $($srvStat.status)"
 
+Start-Sleep -s 10
+
+Add-Content $config "`n<ossec_config>   <client>      <server-ip>$($wazuh_manager)</server-ip>   </client> </ossec_config>"
+
+Start-Sleep -s 10
+
 Write-Output "Starting service."
 Start-Service $srvName
 $srvStat = Get-Service $srvName
 Write-Output "$($srvName) is now $($srvStat.status)"
+}
+Else{
+
+# If agent is found in manager by name it will retrieve the key and configure the agent
+
+$response = req -method "GET" -resource "/agents/$($agentexistid.id)/key" | ConvertFrom-Json
+# Key received from manager
+$agent_key = $response.data
+# Importing agent key from manager
+Write-Output "`r`nImporting authentication key:"
+echo "y" | & "$($path)manage_agents.exe" "-i $($agent_key)" "y`r`n"
+
+Write-Output "`r`nRestarting:"
+$srvName = "OssecSvc"
+
+Write-Output "Stopping service."
+Stop-Service $srvName
+$srvStat = Get-Service $srvName
+Write-Output "$($srvName) is now $($srvStat.status)"
+
+Start-Sleep -s 10
+
+Add-Content $config "`n<ossec_config>   <client>      <server-ip>$($wazuh_manager)</server-ip>   </client> </ossec_config>"
+
+Start-Sleep -s 10
+
+Write-Output "Starting service."
+Start-Service $srvName
+$srvStat = Get-Service $srvName
+Write-Output "$($srvName) is now $($srvStat.status)"
+
+
+}


### PR DESCRIPTION
I've added a couple of useful lines to this script after finding a couple of issues we encountered when trying to migrate existing agents to a new IP address.

The suggested changes I have made:

Script will add the manager IP address to the config file by appending it to the last line.

Script will test it can reach the manager, I found that if the initial IE first run dialogue had not been run through it would stop the GET / POST actions and generate a very ambiguous error code. This part will write a more clear error and append the full error in PoSH.

Script will then check if the agent exists in the manager and if so retrieve the agent key if it already exists in the system and configure the agent appropriately.  If the agent is new it will configure using the original script under the 'if' statement.
 
Hope this is useful!