### PR TITLE
Change output format of manager/logs call to JSON

### DIFF
--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -108,7 +108,7 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
         logs = search_array(logs, search['value'], search['negation'])
 
     if sort:
-        logs = sort_array(logs, order=sort['order'])
+        logs = sort_array(logs, order=sort['order'], sort_by=sort['fields'])
     else:
         logs = sort_array(logs, order='desc', sort_by=['timestamp'])
 

--- a/framework/wazuh/manager.py
+++ b/framework/wazuh/manager.py
@@ -32,13 +32,16 @@ def status():
 
     return data
 
-def __get_ossec_log_category(log):
-    regex_category = re.compile("^\d\d\d\d/\d\d/\d\d\s\d\d:\d\d:\d\d\s(\S+):\s")
+def __get_ossec_log_fields(log):
+    regex_category = re.compile("^(\d\d\d\d/\d\d/\d\d)\s\d\d:\d\d:\d\d\s(\S+):\s(\S+):\s(.+)$")
 
     match = re.search(regex_category, log)
 
     if match:
-        category = match.group(1)
+        date        = match.group(1)
+        category    = match.group(2)
+        type_log    = match.group(3)
+        description = match.group(4)
 
         if "rootcheck" in category:  # Unify rootcheck category
             category = "ossec-rootcheck"
@@ -48,7 +51,7 @@ def __get_ossec_log_category(log):
     else:
         return None
 
-    return category
+    return date, category, type_log, description
 
 
 def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.database_limit, sort=None, search=None):
@@ -70,36 +73,36 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
     statfs_error = "ERROR: statfs('******') produced error: No such file or directory"
 
     for line in tail(common.ossec_log, 2000):
+        date, log_category, level, description = __get_ossec_log_fields(line)
+
         try:
-            log_date = datetime.strptime(line[:10], '%Y/%m/%d')
-        except ValueError:
+            log_date = datetime.strptime(date, '%Y/%m/%d')
+        except ValueError as e:
             continue
 
         if log_date < first_date:
             continue
 
         if category != 'all':
-            log_category = __get_ossec_log_category(line)
-
             if log_category:
                 if log_category != category:
                     continue
             else:
                 continue
 
-        line = line.replace('\n', '')
+        log_line = {'timestamp': date, 'tag': log_category, 'level': level, 'description': description}
         if type_log == 'all':
-            logs.append(line)
-        elif type_log == 'error' and "error:" in line.lower():
+            logs.append(log_line)
+        elif type_log.lower() == level.lower():
             if "ERROR: statfs(" in line:
                 if statfs_error in logs:
                     continue
                 else:
                     logs.append(statfs_error)
             else:
-                logs.append(line)
-        elif type_log == 'info' and "error:" not in line.lower():
-            logs.append(line)
+                logs.append(log_line)
+        else:
+            continue
 
     if search:
         logs = search_array(logs, search['value'], search['negation'])
@@ -107,7 +110,7 @@ def ossec_log(type_log='all', category='all', months=3, offset=0, limit=common.d
     if sort:
         logs = sort_array(logs, order=sort['order'])
     else:
-        logs = sort_array(logs, order='desc')
+        logs = sort_array(logs, order='desc', sort_by=['timestamp'])
 
     return {'items': cut_array(logs, offset, limit), 'totalItems': len(logs)}
 


### PR DESCRIPTION
This PR fixes #28.

The new output of the `GET manager/logs` API call is:
```shellsession
# curl -u foo:bar "localhost:55000/manager/logs?pretty&limit=5"
{
   "error": 0,
   "data": {
      "totalItems": 358,
      "items": [
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.log.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous sha1 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.log.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.json.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous sha1 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.json.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/alerts/2017/Oct/ossec-alerts-14.log.sum'. Starting over.",
            "level": "ERROR"
         }
      ]
   }
}
```

It also supports filtering by category:
```shellsession
# curl -u foo:bar "localhost:55000/manager/logs?pretty&limit=5&category=ossec-rootcheck"
{
   "error": 0,
   "data": {
      "totalItems": 5,
      "items": [
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-rootcheck",
            "description": "Starting rootcheck scan.",
            "level": "INFO"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-rootcheck",
            "description": "Ending rootcheck scan.",
            "level": "INFO"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-rootcheck",
            "description": "Started (pid: 795).",
            "level": "INFO"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-rootcheck",
            "description": "Starting rootcheck scan.",
            "level": "INFO"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-rootcheck",
            "description": "Ending rootcheck scan.",
            "level": "INFO"
         }
      ]
   }
}
```
And by log_type:
```shellsession
# curl -u foo:bar "localhost:55000/manager/logs?pretty&limit=5&type_log=error"
{
   "error": 0,
   "data": {
      "totalItems": 11,
      "items": [
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.log.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous sha1 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.log.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.json.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous sha1 checksum found: '/logs/archives/2017/Oct/ossec-archive-14.json.sum'. Starting over.",
            "level": "ERROR"
         },
         {
            "timestamp": "2017/10/16",
            "tag": "ossec-monitord",
            "description": "No previous md5 checksum found: '/logs/alerts/2017/Oct/ossec-alerts-14.log.sum'. Starting over.",
            "level": "ERROR"
         }
      ]
   }
}
```