### PR TITLE
Fix error with hashlib version

### DIFF
--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -1095,8 +1095,13 @@ class Agent:
             raise WazuhException(1600)
 
         # check hash algorithm
-        if not hash_algorithm in hashlib.algorithms:
-            raise WazuhException(1723, "Available algorithms are {0}.".format(hashlib.algorithms))
+        try:
+            algorithm_list = hashlib.algorithms_available
+        except Exception as e:
+            algorithm_list = hashlib.algorithms
+
+        if not hash_algorithm in algorithm_list:
+            raise WazuhException(1723, "Available algorithms are {0}.".format(algorithm_list))
 
         hashing = hashlib.new(hash_algorithm)
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -13,7 +13,6 @@ from wazuh import manager
 from wazuh import common
 from glob import glob
 from datetime import date, datetime, timedelta
-from hashlib import md5, sha1
 from base64 import b64encode
 from shutil import copyfile, move, copytree
 from time import time
@@ -1096,8 +1095,8 @@ class Agent:
             raise WazuhException(1600)
 
         # check hash algorithm
-        if not hash_algorithm in hashlib.algorithms_available:
-            raise WazuhException(1723)
+        if not hash_algorithm in hashlib.algorithms:
+            raise WazuhException(1723, "Available algorithms are {0}.".format(hashlib.algorithms))
 
         hashing = hashlib.new(hash_algorithm)
 

--- a/framework/wazuh/agent.py
+++ b/framework/wazuh/agent.py
@@ -547,9 +547,9 @@ class Agent:
             epoch_time = int(time())
             str1 = "{0}{1}{2}".format(epoch_time, name, platform())
             str2 = "{0}{1}".format(ip, agent_id)
-            hash1 = md5(str1.encode())
+            hash1 = hashlib.md5(str1.encode())
             hash1.update(urandom(64))
-            hash2 = md5(str2.encode())
+            hash2 = hashlib.md5(str2.encode())
             hash1.update(urandom(64))
             agent_key = hash1.hexdigest() + hash2.hexdigest()
         else:
@@ -1291,13 +1291,13 @@ class Agent:
             item = {}
             item['filename'] = entry
             with open("{0}/{1}".format(group_path, entry), 'rb') as f:
-                item['hash'] = md5(f.read()).hexdigest()
+                item['hash'] = hashlib.md5(f.read()).hexdigest()
             data.append(item)
 
         # ar.conf
         ar_path = "{0}/ar.conf".format(common.shared_path, entry)
         with open(ar_path, 'rb') as f:
-            hash_ar = md5(f.read()).hexdigest()
+            hash_ar = hashlib.md5(f.read()).hexdigest()
         data.append({'filename': "../ar.conf", 'hash': hash_ar})
 
         if search:
@@ -1618,7 +1618,7 @@ class Agent:
         # If WPK is already downloaded
         if path.isfile(wpk_file_path):
             # Get SHA1 file sum
-            sha1hash = sha1(open(wpk_file_path, 'rb').read()).hexdigest()
+            sha1hash = hashlib.sha1(open(wpk_file_path, 'rb').read()).hexdigest()
             # Comparing SHA1 hash
             if not sha1hash == agent_new_shasum:
                 if debug:
@@ -1656,7 +1656,7 @@ class Agent:
             raise WazuhException(1714, error)
 
         # Get SHA1 file sum
-        sha1hash = sha1(open(wpk_file_path, 'rb').read()).hexdigest()
+        sha1hash = hashlib.sha1(open(wpk_file_path, 'rb').read()).hexdigest()
 
         # Comparing SHA1 hash
         if not sha1hash == agent_new_shasum:
@@ -1916,7 +1916,7 @@ class Agent:
         try:
             start_time = time()
             bytes_read = file.read(common.wpk_read_size)
-            file_sha1=sha1(bytes_read)
+            file_sha1=hashlib.sha1(bytes_read)
             bytes_read_acum = 0
             while bytes_read:
                 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)


### PR DESCRIPTION
Hi,

In the API call `GET /agents/groups` a hash digest is computed:
```shellsession
# curl -u foo:bar "localhost:55000/agents/groups?pretty"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "count": 2,
            "conf_sum": "ef87240eca0f9c33edc39d4934af0b29",
            "merged_sum": "3399d30c2cccf39946b88a3bb0d2dd1c",
            "name": "default"
         }
      ]
   }
}
```
The default hashing algorithm is MD5 but the user can choose other algorithms. To know the _available algorithms_ the user can use, the variable `hashlib.algorithms_available` is used. 

This is a problem because that variable was added in _Python 2.7.9_. Users that have _Python 2.7.5_ (in CentOS for example) will get an error. To solve this, I've added a `try... except` call. This way, if the variable `hashlib.algorithms_available` isn't found, the variable `hashlib.algorithms` will be used:

```python
try:
        algorithm_list = hashlib.algorithms_available
except Exception as e:
        algorithm_list = hashlib.algorithms
```
The variable `hashlib.algorithms` has less algorithms defined to use but, al least, the user won't get an error using it 😄 .

Also, I noticed the lib `hashlib` was imported twice so I've fixed that also.

Best regards,
Marta