### PR TITLE
Added select filter to "agents/:agent_id"

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -389,11 +389,19 @@ router.get('/:agent_id', cache(), function(req, res) {
     req.apicacheGroup = "agents";
 
     var data_request = {'function': '/agents/:agent_id', 'arguments': {}};
+    var filters = {'select':'select_param'};
 
     if (!filter.check(req.params, {'agent_id':'numbers'}, req, res))  // Filter with error
         return;
 
     data_request['arguments']['agent_id'] = req.params.agent_id;
+
+    if(!filter.check(req.query, filters, req, res)) // Filter with error
+        return;
+
+    if ('select' in req.query)
+        data_request['arguments']['select'] =
+        filter.select_param_to_json(req.query.select);
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 


### PR DESCRIPTION
# Description
Now the API allows to use the "select" parameter to list specific information fields for the provided agent ID.

Based on the code made for the "/agents/groups" API calls, I added the necessary code to read the filter:

```javascript
var filters = {'select':'select_param'}; 

if(!filter.check(req.query, filters, req, res)) // Filter with error 
        return; 
 
if ('select' in req.query) 
    data_request['arguments']['select'] = 
    filter.select_param_to_json(req.query.select); 
```

No more code is needed in the API to get this working. The other work is part of https://github.com/wazuh/wazuh in the https://github.com/wazuh/wazuh/pull/246 pull request.

# Testing

```shellsession
# curl -u foo:bar -k -X GET "https://localhost:55000/agents/001?pretty&select=group"
{
   "error": 0,
   "data": {
      "status": "Never connected",
      "group": "default",
      "id": "001"
   }
}

# curl -u foo:bar -k -X GET "https://localhost:55000/agents/001?pretty&select=group,name,ip"
{
   "error": 0,
   "data": {
      "status": "Never connected",
      "ip": "192.168.56.101",
      "group": "default",
      "id": "001",
      "name": "AgenteUno"
   }
}
```