### PR TITLE
Option for agent deletion to purge agents definitely from key store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.1.0]
+### Added
+
+- Option for agent deletion to purge agents definitely from keystore.
+
 ## [v3.0.0]
 ### Added
 - Parameter in config.js file to configure the SSL version to use in the API.

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -740,6 +740,7 @@ router.delete('/groups', function(req, res) {
  * @apiGroup Delete
  *
  * @apiParam {Number} agent_id Agent ID.
+ * @apiParam purge Delete agent definitely from the key store.
  *
  * @apiDescription Removes an agent.
  *
@@ -756,6 +757,7 @@ router.delete('/:agent_id', function(req, res) {
         return;
 
     data_request['arguments']['agent_id'] = req.params.agent_id;
+    data_request['arguments']['purge'] = 'purge' in req.query ? true : false;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
@@ -817,6 +819,7 @@ router.delete('/groups/:group_id', function(req, res) {
  * @apiGroup Delete
  *
  * @apiParam {String[]} ids Array of agent ID's.
+ * @apiParam {Boolean} purge Delete agent definitely from the key store.
  *
  * @apiDescription Removes a list of agents. You must restart OSSEC after removing an agent.
  *
@@ -829,8 +832,10 @@ router.delete('/', function(req, res) {
 
     var data_request = {'function': 'DELETE/agents/', 'arguments': {}};
 
-	if (!filter.check(req.body, {'ids':'array_numbers'}, req, res))  // Filter with error
+	if (!filter.check(req.body, {'ids':'array_numbers', 'purge':'boolean'}, req, res))  // Filter with error
         return;
+
+    data_request['arguments']['purge'] = 'purge' in req.body && (req.body['purge'] == true || req.body['purge'] == 'true');
 
     if ('ids' in req.body){
         data_request['arguments']['agent_id'] = req.body.ids;

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -132,3 +132,12 @@ exports.ossec_key = function(param) {
     else
         return false;
 }
+
+exports.boolean = function(n) {
+    if (typeof n != 'undefined'){
+        var regex = /^true|false$/;
+        return regex.test(n);
+    }
+    else
+        return false;
+}


### PR DESCRIPTION
This PR will add a new option to the `DELETE /agents` call:

```
DELETE /agents/001?purge
```
```
DELETE /agents
{ "ids": [1,2,3], "purge": true }
```

This option will make the agent entry to disappear definitely from the key store (file _client.keys_) instead of being invalidated by `!`.

The JSON object supports both boolean and string.