### PR TITLE
Add request to retrieve agents information by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Option for agent deletion to purge agents definitely from keystore.
+- New request: Get agent information by agent name - `GET/agents/name/:agent_name`
 
 ## [v3.0.0]
 ### Added

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -376,6 +376,43 @@ router.get('/outdated', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /agents/name/:agent_name Get an agent by its name
+ * @apiName GetAgentsName
+ * @apiGroup Info
+ *
+ * @apiParam {String} agent_name Agent name.
+ *
+ * @apiDescription Returns the information of an agent called :agent_name.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/name/myAgent?pretty"
+ *
+ */
+router.get('/name/:agent_name', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /agents/name/:agent_name");
+
+    req.apicacheGroup = "agents";
+
+    var data_request = {'function': '/agents/name/:agent_name', 'arguments': {}};
+    var filters = {'select':'select_param'};
+
+    if (!filter.check(req.params, {'agent_name':'names'}, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['agent_name'] = req.params.agent_name;
+
+    if(!filter.check(req.query, filters, req, res)) // Filter with error
+        return;
+
+    if ('select' in req.query)
+        data_request['arguments']['select'] =
+        filter.select_param_to_json(req.query.select);
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+
+})
+
+/**
  * @api {get} /agents/:agent_id Get an agent
  * @apiName GetAgentsID
  * @apiGroup Info

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -165,6 +165,7 @@ if __name__ == "__main__":
 
         functions = {
             '/agents/:agent_id': Agent.get_agent,
+            '/agents/name/:agent_name': Agent.get_agent_by_name,
             '/agents/:agent_id/key': Agent.get_agent_key,
             '/agents': Agent.get_agents_overview,
             '/agents/summary': Agent.get_agents_summary,


### PR DESCRIPTION
Hello,

In this PR I implement the API call requested in issue https://github.com/wazuh/wazuh-api/issues/24: `GET/agents/name/:agent_name`. With this new API call, the user will be able to retrieve agent information by its name:

```shellsession
$ curl -u foo:bar -k http://127.0.0.1:55000/agents?pretty
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Active",
            "name": "node01",
            "ip": "127.0.0.1",
            "dateAdd": "2017-12-05 09:46:17",
            "version": "Wazuh v3.1.0-alpha1",
            "manager_host": "node01",
            "os": {
               "platform": "centos",
               "version": "7",
               "name": "CentOS Linux"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "name": "centos",
            "ip": "192.168.56.105",
            "dateAdd": "2017-12-05 09:46:17",
            "version": "Wazuh v3.0.0-rc2",
            "manager_host": "node01",
            "os": {
               "platform": "centos",
               "version": "7",
               "name": "CentOS Linux"
            },
            "id": "001"
         }
      ]
   }
}
$ curl -u foo:bar -k http://127.0.0.1:55000/agents/name/centos?pretty
{
   "error": 0,
   "data": {
      "status": "Active",
      "group": "default",
      "name": "centos",
      "ip": "192.168.56.105",
      "dateAdd": "2017-12-05 09:46:17",
      "version": "Wazuh v3.0.0-rc2",
      "manager_host": "node01",
      "lastKeepAlive": "2017-12-05 09:42:43",
      "os": {
         "major": "7",
         "name": "CentOS Linux",
         "uname": "Linux manager 3.10.0-514.el7.x86_64 #1 SMP Tue Nov 22 16:42:41 UTC 2016 x86_64",
         "platform": "centos",
         "version": "7",
         "codename": "Core",
         "arch": "x86_64"
      },
      "id": "001"
   }
}
$ curl -u foo:bar -k http://127.0.0.1:55000/agents/name/node01?pretty
{
   "error": 0,
   "data": {
      "status": "Active",
      "name": "node01",
      "ip": "127.0.0.1",
      "dateAdd": "2017-12-05 09:46:17",
      "version": "Wazuh v3.1.0-alpha1",
      "manager_host": "node01",
      "lastKeepAlive": "9999-12-31 23:59:59",
      "os": {
         "major": "7",
         "name": "CentOS Linux",
         "uname": "Linux node01 3.10.0-514.el7.x86_64 #1 SMP Tue Nov 22 16:42:41 UTC 2016 x86_64",
         "platform": "centos",
         "version": "7",
         "codename": "Core",
         "arch": "x86_64"
      },
      "id": "000"
   }
}
```

It's also possible to select fields to be returned, just like the `GET/agents/:agent_id` request:
```shellsession
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/name/node01?pretty&select=os_platform,id"
{
   "error": 0,
   "data": {
      "os": {
         "platform": "centos"
      },
      "id": "000"
   }
}
# curl -u foo:bar -k "http://127.0.0.1:55000/agents/name/centos?pretty&select=id,group"
{
   "error": 0,
   "data": {
      "group": "default",
      "id": "001"
   }
}
```

Best regards,
Marta