### PR TITLE
Add option in configuration to force the use of authd

### DIFF
--- a/configuration/config.js
+++ b/configuration/config.js
@@ -53,7 +53,10 @@ config.python = [
     }
 ];
 // Shared library path
-config.ld_library_path = config.ossec_path + "/api/framework/lib"
+config.ld_library_path = config.ossec_path + "/api/framework/lib";
+
+// Option to force the use of authd to remove and add agents
+config.use_only_authd = false;
 
 /************************* SSL OPTIONS ****************************************/
 // SSL protocol


### PR DESCRIPTION
Hello,

In this PR I've added an new option in API configuration (`config.js` file): force the use of authd to add and remove agents.

```shellsession
# /var/ossec/bin/ossec-control status
ossec-monitord is running...
ossec-logcollector is running...
ossec-remoted is running...
ossec-syscheckd is running...
ossec-analysisd is running...
ossec-maild not running...
ossec-execd is running...
wazuh-modulesd is running...
wazuh-clusterd not running...
# curl -u foo:bar -XPUT "localhost:55000/agents/forcetest?pretty"
{
   "error": 1725,
   "message": "Ossec authd is not running."
}
# curl -u foo:bar -XDELETE "localhost:55000/agents/002?pretty"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not removed",
      "ids": [
         {
            "id": "002",
            "error": {
               "message": "Ossec authd is not running.",
               "code": 1725
            }
         }
      ]
   }
}
# /var/ossec/bin/ossec-control enable auth
# /var/ossec/bin/ossec-control restart
Killing ossec-monitord ..
Killing ossec-logcollector ..
Killing ossec-remoted ..
Killing ossec-syscheckd ..
Killing ossec-analysisd ..
ossec-maild not running ..
Killing ossec-execd ..
Killing wazuh-modulesd ..
wazuh-clusterd not running ..
ossec-authd not running ..
Wazuh v3.1.0-alpha1 Stopped
Starting Wazuh v3.1.0-alpha1 (maintained by Wazuh Inc.)...
Started ossec-authd...
Started wazuh-clusterd...
Started wazuh-modulesd...
Started ossec-execd...
Started ossec-analysisd...
Started ossec-logcollector...
Started ossec-remoted...
Started ossec-syscheckd...
Started ossec-monitord...
Completed.
# curl -u foo:bar -XPUT "localhost:55000/agents/forcetest?pretty"
{
   "error": 0,
   "data": "003"
}
# curl -u foo:bar -XDELETE "localhost:55000/agents/002?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed"
   }
}
```

Best regards,
Marta