### PR TITLE
Update api-register-agent.ps1

### DIFF
--- a/examples/api-register-agent.ps1
+++ b/examples/api-register-agent.ps1
@@ -24,6 +24,7 @@ function Ignore-SelfSignedCerts {
         }
 "@
     [System.Net.ServicePointManager]::CertificatePolicy = new-object PolicyCert
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
 }
 
 function req($method, $resource, $params){
@@ -110,7 +111,7 @@ Write-Output "$($srvName) is now $($srvStat.status)"
 
 Start-Sleep -s 10
 
-Add-Content $config "`n<ossec_config>   <client>      <server-ip>$($wazuh_manager)</server-ip>   </client> </ossec_config>"
+Add-Content $config "`n<ossec_config>   <client>    <server>  <address>$($wazuh_manager)</address> </server>   </client> </ossec_config>"
 
 Start-Sleep -s 10
 
@@ -140,7 +141,7 @@ Write-Output "$($srvName) is now $($srvStat.status)"
 
 Start-Sleep -s 10
 
-Add-Content $config "`n<ossec_config>   <client>      <server-ip>$($wazuh_manager)</server-ip>   </client> </ossec_config>"
+Add-Content $config "`n<ossec_config>   <client>    <server>  <address>$($wazuh_manager)</address> </server>   </client> </ossec_config>"
 
 Start-Sleep -s 10
 


### PR DESCRIPTION
Updates based on trying to use this script in my environment. 

Reference [here](https://virtualbrakeman.wordpress.com/2016/03/20/powershell-could-not-create-ssltls-secure-channel/) for TLS 1.2 setting and [here](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html) for the ossec config changes.