### PR TITLE
Removes temporary test output on /version

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -86,13 +86,7 @@ router.get('/',function(req, res) {
 router.get('/version',function(req, res) {
     logger.debug(req.connection.remoteAddress + " GET /version");
 
-    // Temporary patch
-    if( !req.get('wazuh-app-version') && req.get('user-agent') && req.get('user-agent').startsWith('Needle')){
-        json_res = {'error': 0, 'data': "v3.0.0-beta8"};
-    }
-    else{
-        json_res = {'error': 0, 'data': "v" + info_package.version};
-    }
+    json_res = {'error': 0, 'data': "v" + info_package.version};
 
     res_h.send(req, res, json_res);
 });


### PR DESCRIPTION
```js
const n = require('needle');
n.get('http://192.168.1.66:55000/version',{username:'foo',password:'bar'},(err,resp) => {
	console.log(resp.body); 
        // { error: 0, data: 'v3.1.0' }
});
```

```
$ curl 192.168.1.66:55000/version -u foo:bar
{"error":0,"data":"v3.1.0"}
```