### PR TITLE
Add API call: GET /cluster/node

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -33,6 +33,26 @@ router.get('/nodes', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /cluster/node Get node info
+ * @apiName GetNodeInfo
+ * @apiGroup Node
+ *
+ * @apiDescription Returns the Node info
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node"
+ *
+ */
+router.get('/node', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /cluster/node");
+
+    req.apicacheGroup = "cluster";
+
+    var data_request = {'function': '/cluster/node', 'arguments': {}};
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {get} /cluster/nodes/elected_master Get elected master
  * @apiName GetElectedMaster
  * @apiGroup Nodes
@@ -60,7 +80,7 @@ router.get('/nodes/elected_master', cache(), function(req, res) {
  * @apiDescription Returns the state of each file in the cluster
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/files?pretty""
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/files?pretty"
  *
  */
 router.get('/files', cache(), function(req, res) {
@@ -111,7 +131,7 @@ router.get('/agents', cache(), function(req, res) {
  * @apiDescription Returns if the cluster is enabled or disabled
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/status?pretty""
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/status?pretty"
  *
  */
 router.get('/status', cache(), function(req, res) {

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -83,7 +83,7 @@ router.get('/info', cache(), function(req, res) {
 })
 
 /**
- * @api {get} /manager/info Get manager information
+ * @api {get} /manager/info/:node_id Get manager information
  * @apiName GetManagerInfo
  * @apiGroup Info
  *
@@ -299,7 +299,7 @@ router.get('/stats/weekly', cache(), function(req, res) {
 })
 
 /**
- * @api {get} /manager/stats/weekly Get manager stats by week
+ * @api {get} /manager/stats/weekly/:node_id Get manager stats by week
  * @apiName GetManagerStatsWeekly
  * @apiGroup Stats
  *
@@ -483,7 +483,7 @@ router.get('/logs/summary/:node_id', cache(), function(req, res) {
  * @apiDescription Returns the 3 last months of ossec.log.
  *
  * @apiExample {curl} Example usage*:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/logs/:node01?offset=0&limit=5&pretty"
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/logs/node01?offset=0&limit=5&pretty"
  *
  */
 router.get('/logs/:node_id', cache(), function(req, res) {

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
 
             '/cluster/nodes': cluster.get_nodes,
             '/cluster/nodes/elected_master': cluster.get_actual_master,
-            '/cluster/node': cluster.get_node,
+            '/cluster/node': dapi.get_node_json,
             '/cluster/files': cluster.get_file_status_json,
             '/cluster/agents': Agent.get_cluster_agent_status_json,
             '/cluster/status': cluster.get_status_json,


### PR DESCRIPTION
This PR fixes errors in comments for doc and adds the following call:
GET /cluster/node

## Output sample
GET /cluster/node
```
{
   "error": 0,
   "data": {
      "node_id": "master2",
      "cluster": "wazuh",
      "type": "master(*)"
      "url": "192.168.56.101"
   }
}
```
GET /cluster/node
```
{
   "error": 0,
   "data": {
      "node_id": "node01",
      "cluster": "wazuh",
      "type": "master"
      "url": "192.168.56.105"
   }
}
```