### PR TITLE
Show authenticated user in API logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.3.0]
+### Added
+- Show authenticated user in API logs ([#67](https://github.com/wazuh/wazuh-api/pull/67)).
+
 ## [v3.2.0]
 ### Added
 - Version selector added to `GET /agents` ([#60](https://github.com/wazuh/wazuh-api/pull/60)).

--- a/app.js
+++ b/app.js
@@ -143,11 +143,13 @@ if (config.basic_auth.toLowerCase() == "yes"){
     app.use(auth.connect(auth_secure));
 
     auth_secure.on('fail', (result, req) => {
+        logger.set_user(result.user);
         var log_msg = "[" + req.connection.remoteAddress + "] " + "User: \"" + result.user + "\" - Authentication failed.";
         logger.log(log_msg);
     });
 
     auth_secure.on('error', (error, req) => {
+        logger.set_user("");
         var log_msg = "[" + req.connection.remoteAddress + "] Authentication error: " + error.code + " - " + error.message;
         logger.log(log_msg);
     });

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -38,7 +38,7 @@ apicache.options(cache_opt);
 router.post("*", function(req, res, next) {
     var content_type = req.get('Content-Type');
 
-    if (!content_type || !(content_type == 'application/json' || content_type == 'application/x-www-form-urlencoded' || content_type == 'application/zip')){
+    if (!content_type || !(content_type == 'application/json' || content_type == 'application/x-www-form-urlencoded')){
         logger.debug(req.connection.remoteAddress + " POST " + req.path);
         res_h.bad_request(req, res, "607");
     }
@@ -49,6 +49,7 @@ router.post("*", function(req, res, next) {
 // All requests
 router.all("*", function(req, res, next) {
     var go_next = true;
+    logger.set_user(req.user);
 
     if (req.query){
         // Pretty

--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -20,6 +20,7 @@ var LEVEL_INFO = 1;
 var LEVEL_WARNING = 2;
 var LEVEL_ERROR = 3;
 var LEVEL_DEBUG = 4;
+var user = "";
 
 var logger_level = LEVEL_INFO;
 switch(config.logs) {
@@ -42,12 +43,16 @@ switch(config.logs) {
         logger_level = LEVEL_INFO;
 }
 
+exports.set_user = function(req_user) {
+    user = req_user;
+}
+
 exports.set_foreground = function() {
     foreground = true;
 }
 
 function header(){
-    return tag + " " + moment().format('YYYY-MM-DD HH:mm:ss') + ": ";
+    return tag + " " + moment().format('YYYY-MM-DD HH:mm:ss') + " " + user + ": ";
 }
 
 function write_log(msg){


### PR DESCRIPTION
Hello,

This PR implements a new option in the API logs: show the user who made the request. For example, the following request:

```shellsession
# curl -u marta:bar "localhost:55000?pretty"
{
   "error": 0,
   "data": {
      "msg": "Welcome to Wazuh HIDS API",
      "api_version": "v3.3.0",
      "hostname": "node01",
      "timestamp": "Fri Feb 16 2018 19:11:47 GMT+0100 (CET)"
   }
}
```

will produce the following log line:
```
WazuhAPI 2018-02-16 19:11:47 marta: [::1] GET /?pretty - 200 - error: '0'.
```

If a wrong user is used, the log will show the last correct user:

```shellsession
# curl -u pepe:bar "localhost:55000?pretty"
401 Unauthorized
# tail -n1 /var/ossec/logs/api.log st:55000?pretty"
WazuhAPI 2018-02-16 19:15:15 marta: [::1] User: "pepe" - Authentication failed.
```

Best regards,
Marta