### PR TITLE
Add an option in config.js to run the API as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.2.2]
+## Added
+- Added an option in `config.js` to run the API with root privileges for debug purposes and troubleshoutting. The API runs as ossec by default. ([#68](https://github.com/wazuh/wazuh-api/pull/68))
+
+
 ## [v3.2.1]
 
 There are no changes for Wazuh API in this version.

--- a/app.js
+++ b/app.js
@@ -83,12 +83,14 @@ if (config.https.toLowerCase() == "yes"){
 /********************************************/
 /* Drop privileges
 /********************************************/
-try {
-    process.setgid('ossec');
-    process.setuid('ossec');
-} catch(err) {
-    console.log('Drop privileges failed: ' + err.message);
-    process.exit(1);
+if (config.drop_privileges || config.drop_privileges == undefined) {
+    try {
+        process.setgid('ossec');
+        process.setuid('ossec');
+    } catch(err) {
+        console.log('Drop privileges failed: ' + err.message);
+        process.exit(1);
+    }
 }
 
 /********************************************/

--- a/configuration/config.js
+++ b/configuration/config.js
@@ -58,6 +58,9 @@ config.ld_library_path = config.ossec_path + "/framework/lib"
 // Option to force the use of authd to remove and add agents
 config.use_only_authd = false;
 
+// Option to drop privileges (run as ossec)
+config.drop_privileges = true;
+
 /************************* SSL OPTIONS ****************************************/
 // SSL protocol
 


### PR DESCRIPTION
Hello,

The API runs as ossec at this moment and has no option to choose whether to run with privileges or not. With this PR, an option in configuration is added to control this behaviour:

https://github.com/wazuh/wazuh-api/blob/75c56fa9a9d397eca13d2dc1cfae7d7153ebe776/configuration/config.js#L61-L62

This option is checked when the API starts:
https://github.com/wazuh/wazuh-api/blob/75c56fa9a9d397eca13d2dc1cfae7d7153ebe776/app.js#L83-L94

When it set to `true` or is not defined in the configuration, the API will run as `ossec` but when it is set to `false`, the API will run as `root`.

Best regards,
Marta