### PR TITLE
Fix agents purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-
-## [v3.3.0]
-### Added
-- A parameter in request `GET/agents` to filter by a timeframe ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-- New filters in request `REMOVE/agents`:
-    - `timeframe`: Filter to remove agents not connected in a specific time ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-    - `status`: Filter to remove agents with a specific status ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-
-### Changed
-- Filter `status` in `GET/agents` can filter by several status separated by commas ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-
-### Removed
-- The following requests have been removed: 
-    - `POST/agents/purge` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-    - `GET/agents/purgeable` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
-
 ## [v3.2.3]
 ### Added
 - New API requests:
@@ -26,15 +10,26 @@ All notable changes to this project will be documented in this file.
     * `GET/cluster/nodes/:node_name`.
 - A parameter in request `GET/rules` to filter by GDPR requirements ([#78](https://github.com/wazuh/wazuh-api/pull/78)).
 - Parameters in `GET/cluster/nodes`: `search`, `sort`, `offset`, `limit`, `select`. And a new filter: `type`.
-- A parameter in request `GET/agents` to filter agents by cluster nodes.
+- Parameters in request `GET/agents`:
+    * `node_name`: Filters agents by cluster nodes.
+    - `older_than`: Filters by agents not connected in a specific time ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+    - `status`: Filters agents with a specific status ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+- New filters in request `DELETE/agents`:
+    - `older_than`: Filters by agents not connected in a specific time ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+    - `status`: Filters agents with a specific status ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+
 ### Changed
-- Output of `GET/nodes`: Added a new attribute `version`.
+- Output of `GET/nodes`: Added new attribute `version`.
+- Output of `DELETE/agents`: Added new attribute `older_than`.
+- Filter `status` in `GET/agents` can filter by several status separated by commas ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
 
 ### Removed
 - The following requests have been removed: 
     - `GET/cluster/agents`: Duplicated request (`GET/agents`).
     - `GET/cluster/node`: Duplicated request (`GET/cluster/config`).
     - `GET/cluster/files`: It will not be available in this version of the cluster.
+    - `POST/agents/purge`: Replaced by `DELETE/agents` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+    - `GET/agents/purgeable`: Replaced by `GET/agents` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
 
 ## [v3.2.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+
+## [v3.3.0]
+### Added
+- A parameter in request `GET/agents` to filter by a timeframe ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+- New filters in request `REMOVE/agents`:
+    - `timeframe`: Filter to remove agents not connected in a specific time ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+    - `status`: Filter to remove agents with a specific status ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+
+### Changed
+- Filter `status` in `GET/agents` can filter by several status separated by commas ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+
+### Removed
+- The following requests have been removed: 
+    - `POST/agents/purge` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+    - `GET/agents/purgeable` ([#82](https://github.com/wazuh/wazuh-api/pull/82)).
+
 ## [v3.2.3]
 ### Added
 - New API requests:

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -936,8 +936,9 @@ router.delete('/', function(req, res) {
     if (!filter.check(req.query, filter_query, req, res))  // Filter with error
         return;
 
-    if (!('ids' in req.body) && !('older_than' in req.query) && !('status' in req.query))
-        res_h.bad_request(req, res, 604, "Missing field: You have to specified 'older_than', 'ids' or status.");
+    if (!('ids' in req.body) && !('status' in req.query))
+        res_h.bad_request(req, res, 604, "Missing field: You have to specified 'ids' or status.");
+        return;
 
     data_request['arguments']['purge'] = 'purge' in req.body && (req.body['purge'] == true || req.body['purge'] == 'true');
 

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -41,7 +41,7 @@ router.get('/', cache(), function(req, res) {
     var data_request = {'function': '/agents', 'arguments': {}};
     var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param',
                    'select':'select_param', 'search':'search_param',
-                    'status':'status_type', 'os.platform':'alphanumeric_param',
+                    'status':'alphanumeric_param', 'os.platform':'alphanumeric_param',
                    'os.version':'alphanumeric_param', 'manager':'alphanumeric_param',
                    'version':'alphanumeric_param', 'node': 'alphanumeric_param',
                     'timeframe':'timeframe_type'};
@@ -929,7 +929,7 @@ router.delete('/', function(req, res) {
 
     var data_request = { 'function': 'DELETE/agents/', 'arguments': {} };
     var filter_body = { 'ids': 'array_numbers', 'purge': 'boolean' };
-    var filter_query = { 'timeframe': 'timeframe_type', 'status': 'status_type'};
+    var filter_query = { 'timeframe': 'timeframe_type', 'status': 'alphanumeric_param'};
 
     if (!filter.check(req.body, filter_body, req, res))  // Filter with error
         return;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -929,7 +929,7 @@ router.delete('/', function(req, res) {
 
     var data_request = { 'function': 'DELETE/agents/', 'arguments': {} };
     var filter_body = { 'ids': 'array_numbers', 'purge': 'boolean' };
-    var filter_query = { 'timeframe': 'timeframe_type', 'status': 'status_type2'};
+    var filter_query = { 'timeframe': 'timeframe_type', 'status': 'status_type'};
 
     if (!filter.check(req.body, filter_body, req, res))  // Filter with error
         return;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -22,7 +22,7 @@ var router = require('express').Router();
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
  * @apiParam {String="active", "pending", "neverconnected", "disconnected"} [status] Filters by agent status. Use commas to enter multiple statuses.
- * @apiParam {String} older_than Filters out disconnected agents for longer than specified. Time in seconds or [n_days]d[n_hours]h[n_minutes]m[n_seconds]s. For never connected agents, uses the register date.
+ * @apiParam {String} older_than Filters out disconnected agents for longer than specified. Time in seconds | "[n_days]d" | "[n_hours]h" | "[n_minutes]m" | "[n_seconds]s". For never connected agents, uses the register date.
  * @apiParam {String} [os.platform] Filters by OS platform.
  * @apiParam {String} [os.version] Filters by OS version.
  * @apiParam {String} [manager] Filters by manager hostname to which agents are connected.
@@ -915,7 +915,7 @@ router.delete('/groups/:group_id', function(req, res) {
  * @apiParam {String[]} ids Array of agent ID's.
  * @apiParam {Boolean} purge Delete an agent from the key store.
  * @apiParam {String="active", "pending", "neverconnected", "disconnected"} [status] Filters by agent status. Use commas to enter multiple statuses.
- * @apiParam {String} older_than Filters out disconnected agents for longer than specified. Time in seconds or [n_days]d[n_hours]h[n_minutes]m[n_seconds]s. For never connected agents, uses the register date.
+ * @apiParam {String} older_than Filters out disconnected agents for longer than specified. Time in seconds | "[n_days]d" | "[n_hours]h" | "[n_minutes]m" | "[n_seconds]s". For never connected agents, uses the register date.
  *
  * @apiDescription Removes agents, using a list of them or a criterion based on the status or time of the last connection. The Wazuh API must be restarted after removing an agent.
  *

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -49,11 +49,9 @@ errors['ossec_key'] = 615;
 errors['616'] = "Param not valid. Valid characters: array of numbers";
 errors['array_numbers'] = 616;
 errors['timeframe_type'] = 617;
-errors['617'] = "Param not valid. Valid characters: '[0-9]d[0-9]h[0-9]m[0-9]s' or 0-9"
+errors['617'] = "Param not valid. Valid characters: [0-9]d|[0-9]h|[0-9]m|[0-9]s|0-9"
 errors['boolean'] = 618;
 errors['618'] = "Param not valid. Valid characters: true or false"
-errors['status_type'] = 619;
-errors['619'] = "Param not valid. Valid characters: active/disconnected/nerverconnected/pending[,status2,...]"
 
 errors['700'] = "File not found"
 

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -49,9 +49,11 @@ errors['ossec_key'] = 615;
 errors['616'] = "Param not valid. Valid characters: array of numbers";
 errors['array_numbers'] = 616;
 errors['timeframe_type'] = 617;
-errors['617'] = "Param not valid. Valid characters: \"[0-9]d[0-9]h[0-9]m[0-9]s\" or 0-9"
+errors['617'] = "Param not valid. Valid characters: '[0-9]d[0-9]h[0-9]m[0-9]s' or 0-9"
 errors['boolean'] = 618;
 errors['618'] = "Param not valid. Valid characters: true or false"
+errors['status_type'] = 619;
+errors['619'] = "Param not valid. Valid characters: active/disconnected/nerverconnected/pending[,status2,...]"
 
 errors['700'] = "File not found"
 

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -136,7 +136,7 @@ exports.ossec_key = function(param) {
 // [n_days]d[n_hours]h[n_minutes]m[n_seconds]s
 exports.timeframe_type = function(param) {
     if (typeof param != 'undefined'){
-        var regex = /^((\d{1,}[d]){0,1}(\d{1,}[h]){0,1}(\d{1,}[m]){0,1}(\d{1,}[s]){0,1}){1}$|^\d{1,}$/;
+        var regex = /^(\d{1,}[d|h|m|s]?){1}$/;
         return regex.test(param);
     }
     else

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -151,3 +151,21 @@ exports.boolean = function(n) {
     else
         return false;
 }
+
+exports.status_type = function (n) {
+    if (typeof n != 'undefined') {
+        var regex = /^((^|,)(active|neverconnected|pending|disconnected))+$/i;
+        return regex.test(n);
+    }
+    else
+        return false;
+}
+
+exports.status_type2 = function (n) {
+    if (typeof n != 'undefined') {
+        var regex = /^((^|,)(neverconnected|disconnected))+$/i;
+        return regex.test(n);
+    }
+    else
+        return false;
+}

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -151,12 +151,3 @@ exports.boolean = function(n) {
     else
         return false;
 }
-
-exports.status_type = function (n) {
-    if (typeof n != 'undefined') {
-        var regex = /^((^|,)(active|neverconnected|pending|disconnected))+$/i;
-        return regex.test(n);
-    }
-    else
-        return false;
-}

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -160,12 +160,3 @@ exports.status_type = function (n) {
     else
         return false;
 }
-
-exports.status_type2 = function (n) {
-    if (typeof n != 'undefined') {
-        var regex = /^((^|,)(neverconnected|disconnected))+$/i;
-        return regex.test(n);
-    }
-    else
-        return false;
-}

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -72,7 +72,7 @@ exports.ips = function(ip) {
 
 exports.alphanumeric_param = function(param) {
     if (typeof param != 'undefined'){
-        var regex = /^[a-zA-Z0-9_\-\.\+\s]+$/;
+        var regex = /^[a-zA-Z0-9_,\-\.\+\s]+$/;
         return regex.test(param);
     }
     else

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":
             'POST/agents/insert': Agent.insert_agent,
             'DELETE/agents/groups': Agent.remove_group,
             'DELETE/agents/:agent_id': Agent.remove_agent,
-            'DELETE/agents/': Agent.remove_agent,
+            'DELETE/agents/': Agent.remove_agents,
 
             # Groups
             '/agents/groups': Agent.get_all_groups,
@@ -204,8 +204,6 @@ if __name__ == "__main__":
             'PUT/agents/groups/:group_id': Agent.create_group,
             'DELETE/agents/groups/:group_id':Agent.remove_group,
             'DELETE/agents/:agent_id/group':Agent.unset_group,
-            'POST/agents/purge': Agent.purge_agents,
-            '/agents/purgeable/:timeframe': Agent.get_purgeable_agents_json,
 
             # Decoders
             '/decoders': Decoder.get_decoders,

--- a/test/README.md
+++ b/test/README.md
@@ -3,9 +3,12 @@
 ## Requirements
 
  * API installed and configurated (Configure API: https and auth (foo:bar)).
- * Packages npm installed: `glob`, `supertest`, `mocha`, `should`, `moment` and `getos`.
+ * Packages npm installed: `glob`, `supertest`, `mocha`, `should`, `moment`, `sleep` and `getos`.
  
-    ``` npm install glob supertest mocha should moment getos ```
+    ``` 
+    npm install mocha -g
+    npm install glob supertest mocha should moment getos sleep
+    ```
 
  * Cluster configurated and running with 2 connected nodes: `master` and `client`.
  * A connected agent with id `001`.

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -168,9 +168,9 @@ describe('Agents', function() {
             });
         });
 
-        it('Filters: timeframe', function (done) {
+        it('Filters: older_than', function (done) {
             request(common.url)
-                .get("/agents?timeframe=1s")
+                .get("/agents?older_than=1s")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(400)
@@ -986,9 +986,9 @@ describe('Agents', function() {
                 });
         });
 
-        it('Filter: timeframe, status and ids', function (done) {
+        it('Filter: older_than, status and ids', function (done) {
             request(common.url)
-                .delete("/agents?status=neverconnected&timeframe=1s")
+                .delete("/agents?status=neverconnected&older_than=1s")
                 .send({ 'ids': [agent_id1]})
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
@@ -997,7 +997,7 @@ describe('Agents', function() {
                     if (err) return done(err);
 
                     res.body.should.have.properties(['error', 'data']);
-                    res.body.data.should.have.properties(['affected_agents', 'msg', 'timeframe']);
+                    res.body.data.should.have.properties(['affected_agents', 'msg', 'older_than']);
 
                     res.body.data.affected_agents[0].should.equal(agent_id1);
 
@@ -1021,9 +1021,9 @@ describe('Agents', function() {
                 });
         });
         
-        it('Filter: timeframe', function (done) {
+        it('Filter: older_than', function (done) {
             request(common.url)
-                .delete("/agents?timeframe=1s")
+                .delete("/agents?older_than=1s")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -1031,7 +1031,7 @@ describe('Agents', function() {
                     if (err) return done(err);
 
                     res.body.should.have.properties(['error', 'data']);
-                    res.body.data.should.have.properties(['affected_agents', 'msg', 'timeframe']);
+                    res.body.data.should.have.properties(['affected_agents', 'msg', 'older_than']);
 
                     res.body.error.should.equal(0);
                     done();

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -13,6 +13,7 @@ var should  = require('should');
 var assert  = require('assert');
 var request = require('supertest');
 var common  = require('./common.js');
+var sleep = require('sleep');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -116,6 +117,25 @@ describe('Agents', function() {
             });
         });
 
+        it('Filters: status 2', function (done) {
+            request(common.url)
+                .get("/agents?status=aCtIvE,neverconnected")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['status', 'ip', 'id', 'name']);
+                    done();
+                });
+        });
+
         it('Filters: Invalid filter', function(done) {
             request(common.url)
             .get("/agents?random")
@@ -147,6 +167,25 @@ describe('Agents', function() {
                 done();
             });
         });
+
+        it('Filters: timeframe', function (done) {
+            request(common.url)
+                .get("/agents?timeframe=1s")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['status', 'ip', 'id', 'name']);
+                    done();
+                });
+        });
+
 
     });  // GET/agents
 
@@ -490,7 +529,7 @@ describe('Agents', function() {
 
         it('Search', function (done) {
             request(common.url)
-                .get("/agents/no_group?search=1")
+                .get("/agents/no_group?search=" + agent_id)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -892,5 +931,115 @@ describe('Agents', function() {
         });
 
     });  // PUT/agents/:agent_id/restart
+
+
+
+    describe('DELETE/agents', function () {
+
+        var agent_name1 = "agentToDelete"
+        var agent_name2 = "agentToDelete2"
+        var agent_id1 = 0
+        var agent_id2 = 0
+        before(function (done) {
+            request(common.url)
+                .put("/agents/" + agent_name1)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) throw err;
+                    agent_id1 = res.body.data.id;
+                    done();
+                });
+        });
+
+        before(function (done) {
+
+            request(common.url)
+                .put("/agents/" + agent_name2)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) throw err;
+                    agent_id2 = res.body.data.id;
+                    done();
+                });
+        });
+
+        before(function (done) {
+            sleep.sleep(1)
+            done();
+        });
+
+        it('Request', function (done) {
+            request(common.url)
+                .delete("/agents")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'message']);
+                    done();
+                });
+        });
+
+        it('Filter: timeframe, status and ids', function (done) {
+            request(common.url)
+                .delete("/agents?status=neverconnected&timeframe=1s")
+                .send({ 'ids': [agent_id1]})
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.should.have.properties(['affected_agents', 'msg', 'timeframe']);
+
+                    res.body.data.affected_agents[0].should.equal(agent_id1);
+
+                    res.body.error.should.equal(0);
+                    done();
+                });
+        });
+
+        it('Errors: Get deleted agent', function (done) {
+            request(common.url)
+                .get("/agents/" + agent_id1)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'message']);
+                    res.body.error.should.equal(1701);
+                    done();
+                });
+        });
+        
+        it('Filter: timeframe', function (done) {
+            request(common.url)
+                .delete("/agents?timeframe=1s")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.should.have.properties(['affected_agents', 'msg', 'timeframe']);
+
+                    res.body.error.should.equal(0);
+                    done();
+                });
+        });
+        
+    });  // DELETE/agents
+
+
 
 });  // Agents


### PR DESCRIPTION
Hello team,

this PR solves the issue https://github.com/wazuh/wazuh-api/issues/79, and it's part of https://github.com/wazuh/wazuh/tree/fix-agents-purge.

## Remove
* `POST/agents/purge`
* `GET/agents/purgeable`

## Add
* Filter `status` in `GET/agents` can filter by several status separated by commas. Sample: 
```
$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?status=Disconnected,neverconnected&pretty"
```
* Added new filter to `GET/agents` resquest: `timeframe`. Timeframe filters out agents that have not connected within the specified time. In case of having `never connected` status, filter using the date they were registered. Sample:
```
$ date
Tue May 22 09:49:01 UTC 2018

$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&timeframe=1s&status=neverconnected"
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:27:49",
            "name": "agent001",
            "ip": "any",
            "id": "001",
            "node_name": "unknown"
         },
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:28:19",
            "name": "agent004",
            "ip": "any",
            "id": "004",
            "node_name": "unknown"
         },
         {
            "status": "Never connected",
            "dateAdd": "2018-05-22 09:36:31",
            "name": "agent_test1",
            "ip": "any",
            "id": "007",
            "node_name": "unknown"
         }
      ]
   }
}

$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&timeframe=1h&status=neverconnected"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:27:49",
            "name": "agent001",
            "ip": "any",
            "id": "001",
            "node_name": "unknown"
         },
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:28:19",
            "name": "agent004",
            "ip": "any",
            "id": "004",
            "node_name": "unknown"
         }
      ]
   }
}
```
```
$ date
Tue May 22 09:55:53 UTC 2018

$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&timeframe=2d&status=neverconnected,disconnected"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "default",
            "name": "agent005",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node01",
            "dateAdd": "2018-05-20 09:55:29",
            "version": "Wazuh v3.2.3",
            "manager_host": "manager",
            "lastKeepAlive": "2018-05-20 09:55:29",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |manager |3.10.0-693.17.1.el7.x86_64 |#1 SMP Thu Jan 25 20:13:58 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "005"
         }
      ]
   }
}
```
* Added `timeframe` and `status` filter to `DELETE /agents`. It's possible to delete agents not connected at a specific time with a specific status. By default, timeframe is `7d` (7 days). Samples:

Remove all agents that have been disconnected for the last week, or added more than a week ago and are never connected:

```
$ date
Tue May 22 10:09:57 UTC 2018

$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/003?pretty"
{
   "error": 0,
   "data": {
      "status": "Disconnected",
      "configSum": "ab73af41699f13fdd81903b5f23d8d00",
      "name": "agent003",
      "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
      "ip": "any",
      "dateAdd": "2018-05-15 10:09:09",
      "version": "Wazuh v3.2.3",
      "manager_host": "manager",
      "lastKeepAlive": "2018-05-15 10:09:09",
      "os": {
         "major": "7",
         "name": "CentOS Linux",
         "uname": "Linux |manager |3.10.0-693.17.1.el7.x86_64 |#1 SMP Thu Jan 24 10:13:58 UTC 2018 |x86_64",
         "platform": "centos",
         "version": "7",
         "codename": "Core",
         "arch": "x86_64"
      },
      "id": "003"
   }
}

$ curl -u foo:bar -k -X DELETE "http://127.0.0.1:55000/agents?pretty&status=disconnected,neverconnected"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "003"
      ]
   }
}
```
Remove all agents from a list that have not been active from more than 1 day:
```
$ date
Tue May 22 10:14:41 UTC 2018

$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&timeframe=1d"       
{
   "error": 0,
   "data": {
      "totalItems": 3,
      "items": [
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:27:49",
            "name": "agent001",
            "ip": "any",
            "id": "001",
            "node_name": "unknown"
         },
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "name": "agent003",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node01",
            "dateAdd": "2018-05-21 09:28:08",
            "version": "Wazuh v3.2.3",
            "manager_host": "manager",
            "lastKeepAlive": "2018-05-15 10:09:09",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |manager |3.10.0-693.17.1.el7.x86_64 |#1 SMP Thu Jan 24 10:13:58 UTC 2018 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "003"
         },
         {
            "status": "Never connected",
            "dateAdd": "2018-05-21 09:28:19",
            "name": "agent004",
            "ip": "any",
            "id": "004",
            "node_name": "unknown"
         }
      ]
   }
}

$ curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["003","004","006"]}' "http://127.0.0.1:55000/agents?pretty&timeframe=1d"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not removed",
      "failed_ids": [
         {
            "id": "006",
            "error": {
               "message": "Agent is not eligible for removal: The agent has a status different to 'all' or the specified timeframe '1d' does not apply.",
               "code": 1731
            }
         }
      ],
      "affected_agents": [
         "003",
         "004"
      ]
   }
}
```

Delete all agents never connected:
```
$ /var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: manager (server), IP: 127.0.0.1, Active/Local
   ID: 002, Name: agent002, IP: any, Disconnected
   ID: 005, Name: agent005, IP: any, Disconnected
   ID: 007, Name: agent_test1, IP: any, Never connected
   ID: 008, Name: agent_nc1, IP: any, Never connected
   ID: 009, Name: agent_nc2, IP: any, Never connected

List of agentless devices:

$ curl -u foo:bar -k -X DELETE "http://127.0.0.1:55000/agents?pretty&status=neverconnected&timeframe=1s"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "007",
         "008",
         "009"
      ]
   }
}
$ /var/ossec/bin/agent_control -l

Wazuh agent_control. List of available agents:
   ID: 000, Name: manager (server), IP: 127.0.0.1, Active/Local
   ID: 002, Name: agent002, IP: any, Disconnected
   ID: 005, Name: agent005, IP: any, Disconnected

List of agentless devices:
```

Regards.