### PR TITLE
Fix wazuh-api.service file #86

### DIFF
--- a/scripts/install_daemon.sh
+++ b/scripts/install_daemon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2015-2016 Wazuh, Inc.All rights reserved.
+# Copyright (C) 2015-2018 Wazuh, Inc.All rights reserved.
 # Wazuh.com
 # This program is a free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public

--- a/scripts/wazuh-api
+++ b/scripts/wazuh-api
@@ -1,6 +1,11 @@
 #!/bin/sh
 # WAZUH API Service
-# Author: Wazuh
+# Copyright (C) 2015-2018 Wazuh, Inc.All rights reserved.
+# Wazuh.com
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
 
 ### BEGIN INIT INFO
 # Provides:          wazuh_api

--- a/scripts/wazuh-api.service
+++ b/scripts/wazuh-api.service
@@ -1,6 +1,11 @@
 # WAZUH API Service (Systemd unit)
-# Wazuh Inc.
-# April 11, 2016
+#
+# Copyright (C) 2015-2018 Wazuh, Inc.All rights reserved.
+# Wazuh.com
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
 
 [Unit]
 Description=Wazuh API daemon
@@ -11,6 +16,8 @@ After=network-online.target
 Type=simple
 ExecStart=
 Environment=NODE_ENV=production
+ExecStop=/bin/kill -HUP $MAINPID
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi team,

in this PR I solve the issue #86. In order to fix this, I add the following lines to the `wazuh-api.service`:
```
ExecStop=/bin/kill -HUP $MAINPID
KillMode=process
```
These lines will kill the wazuh-api process by its PID when you execute `systemctl stop wazuh-api`.

You can check the output of starting and stopping the wazuh-api right down:
* Start the wazuh-api:

    ```
    [root@d0240e42b8b8 /]# systemctl start wazuh-api
    [root@d0240e42b8b8 /]# curl -u foo:bar -k -X GET "http://127.0.0.1:55000?pretty"
    {
       "error": 0,
       "data": {
          "msg": "Welcome to Wazuh HIDS API",
          "api_version": "v3.2.4",
          "hostname": "d0240e42b8b8",
          "timestamp": "Tue Jun 05 2018 11:01:39 GMT+0000 (UTC)"
       }
    }
    [root@d0240e42b8b8 /]# systemctl status wazuh-api
    ● wazuh-api.service - Wazuh API daemon
       Loaded: loaded (/etc/systemd/system/wazuh-api.service; enabled; vendor preset: disabled)
       Active: active (running) since Tue 2018-06-05 11:01:32 UTC; 10s ago
         Docs: https://documentation.wazuh.com/current/user-manual/api/index.html
      Process: 2609 ExecStop=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
     Main PID: 2613 (node)
       CGroup: /docker/d0240e42b8b841df15cf4ce31832ef32783c63c021bd55b82b38fc0e881be032/system.slice/wazuh-api.service
               └─2613 /bin/node /var/ossec/api/app.js

    Jun 05 11:01:32 d0240e42b8b8 systemd[1]: Started Wazuh API daemon.
    Jun 05 11:01:32 d0240e42b8b8 systemd[1]: Starting Wazuh API daemon...
     ```
* Stop the wazuh-api:

    ```
    [root@d0240e42b8b8 /]# systemctl stop wazuh-api
    [root@d0240e42b8b8 /]# systemctl status wazuh-api
    ● wazuh-api.service - Wazuh API daemon
       Loaded: loaded (/etc/systemd/system/wazuh-api.service; enabled; vendor preset: disabled)
       Active: inactive (dead) since Tue 2018-06-05 11:01:46 UTC; 2s ago
         Docs: https://documentation.wazuh.com/current/user-manual/api/index.html
      Process: 2629 ExecStop=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
      Process: 2613 ExecStart=/bin/node /var/ossec/api/app.js (code=killed, signal=HUP)
     Main PID: 2613 (code=killed, signal=HUP)

    Jun 05 11:01:32 d0240e42b8b8 systemd[1]: Started Wazuh API daemon.
    Jun 05 11:01:32 d0240e42b8b8 systemd[1]: Starting Wazuh API daemon...
    Jun 05 11:01:46 d0240e42b8b8 systemd[1]: Stopping Wazuh API daemon...
    Jun 05 11:01:46 d0240e42b8b8 systemd[1]: Stopped Wazuh API daemon.
    [root@d0240e42b8b8 /]# curl -u foo:bar -k -X GET "http://127.0.0.1:55000?pretty"
    curl: (7) Failed connect to 127.0.0.1:55000; Connection refused
    ```

Regards,  
Braulio
