### PR TITLE
Refactor filters in GET/agents and GET/agents/groups/:group_id requests

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -45,10 +45,12 @@ router.get('/', cache(), function(req, res) {
                     'status':'alphanumeric_param', 'os.platform':'alphanumeric_param',
                    'os.version':'alphanumeric_param', 'manager':'alphanumeric_param',
                    'version':'alphanumeric_param', 'node': 'alphanumeric_param',
-                    'older_than':'timeframe_type'};
+                    'older_than':'timeframe_type', 'group':'alphanumeric_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
+
+    data_request['arguments']['filters'] = {}
 
     if ('offset' in req.query)
         data_request['arguments']['offset'] = req.query.offset;
@@ -61,19 +63,21 @@ router.get('/', cache(), function(req, res) {
     if ('select' in req.query)
         data_request['arguments']['select'] = filter.select_param_to_json(req.query.select);
     if ('status' in req.query)
-        data_request['arguments']['status'] = req.query.status;
+        data_request['arguments']['filters']['status'] = req.query.status;
     if ('os.platform' in req.query)
-        data_request['arguments']['os_platform'] = req.query['os.platform'];
+        data_request['arguments']['filters']['os_platform'] = req.query['os.platform'];
     if ('os.version' in req.query)
-        data_request['arguments']['os_version'] = req.query['os.version'];
+        data_request['arguments']['filters']['os_version'] = req.query['os.version'];
     if ('manager' in req.query)
-        data_request['arguments']['manager_host'] = req.query['manager'];
+        data_request['arguments']['filters']['manager_host'] = req.query['manager'];
     if ('node' in req.query)
-        data_request['arguments']['node_name'] = req.query['node'];
+        data_request['arguments']['filters']['node_name'] = req.query['node'];
     if ('version' in req.query)
-        data_request['arguments']['version'] = req.query['version'];
+        data_request['arguments']['filters']['version'] = req.query['version'];
     if ('older_than' in req.query)
-        data_request['arguments']['older_than'] = req.query['older_than'];
+        data_request['arguments']['filters']['older_than'] = req.query['older_than'];
+    if ('group' in req.query)
+        data_request['arguments']['filters']['group'] = req.query['group'];
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
@@ -508,7 +512,7 @@ router.get('/:agent_id', cache(), function(req, res) {
 /**
  * @api {get} /agents/:agent_id/key Get agent key
  * @apiName GetAgentsKey
- * @apiGroup Key 
+ * @apiGroup Key
  *
  * @apiParam {Number} agent_id Agent ID.
  *
@@ -951,7 +955,7 @@ router.delete('/', function(req, res) {
 
     if ('status' in req.query)
         data_request['arguments']['status'] = req.query.status;
-    
+
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -249,7 +249,9 @@ router.get('/groups/:group_id', cache(), function(req, res) {
     req.apicacheGroup = "agents";
 
     var data_request = {'function': '/agents/groups/:group_id', 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param', 'select':'select_param'};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param',
+                   'search':'search_param', 'select':'select_param',
+                   'status': 'alphanumeric_param'};
 
     if (!filter.check(req.params, {'group_id':'names'}, req, res))  // Filter with error
         return;
@@ -259,6 +261,8 @@ router.get('/groups/:group_id', cache(), function(req, res) {
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
+
+    data_request['arguments']['filters'] = {}
 
     if ('offset' in req.query)
         data_request['arguments']['offset'] = req.query.offset;
@@ -270,6 +274,8 @@ router.get('/groups/:group_id', cache(), function(req, res) {
         data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
     if ('select' in req.query)
         data_request['arguments']['select'] = filter.select_param_to_json(req.query.select);
+    if ('status' in req.query)
+        data_request['arguments']['filters']['status'] = req.query.status;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -165,10 +165,14 @@ router.get('/no_group', cache(), function (req, res) {
     req.apicacheGroup = "agents";
 
     var data_request = { 'function': '/agents/no_group', 'arguments': {} };
-    var filters = { 'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param', 'select': 'select_param', 'search': 'search_param' };
+    var filters = { 'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
+                    'select': 'select_param', 'search': 'search_param',
+                    'status': 'alphanumeric_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
+
+    data_request['arguments']['filters'] = {}
 
     if ('offset' in req.query)
         data_request['arguments']['offset'] = req.query.offset;
@@ -180,6 +184,8 @@ router.get('/no_group', cache(), function (req, res) {
         data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
     if ('select' in req.query)
         data_request['arguments']['select'] = filter.select_param_to_json(req.query.select);
+    if ('status' in req.query)
+        data_request['arguments']['filters']['status'] = req.query.status;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -186,6 +186,25 @@ describe('Agents', function() {
                 });
         });
 
+        it('Filters: group', function (done) {
+            request(common.url)
+                .get("/agents?group=default")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['items','totalItems']);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array);
+                    res.body.data.items[0].group.should.be.equal('default')
+
+                    done();
+                });
+        });
+
 
     });  // GET/agents
 
@@ -654,6 +673,38 @@ describe('Agents', function() {
             });
         });
 
+        it('Select', function(done) {
+            request(common.url)
+            .get("/agents/groups/webserver?select=lastKeepAlive,version")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['totalItems', 'items']);
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Filter: status', function(done) {
+            request(common.url)
+            .get("/agents/groups/webserver?status=Active,Disconnected")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['totalItems', 'items']);
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
     });  // GET/agents/groups/:group_id
 
     describe('GET/agents/groups/:group_id/configuration', function() {
@@ -1020,7 +1071,7 @@ describe('Agents', function() {
                     done();
                 });
         });
-        
+
         it('Filter: older_than', function (done) {
             request(common.url)
                 .delete("/agents?older_than=1s")
@@ -1037,7 +1088,7 @@ describe('Agents', function() {
                     done();
                 });
         });
-        
+
     });  // DELETE/agents
 
 

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -300,6 +300,38 @@ describe('Agents', function() {
                 done();
             });
         });
+
+        it('Select', function(done) {
+            request(common.url)
+            .get("/agents/000?select=lastKeepAlive,id,ip,status")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.error.should.equal(0);
+                res.body.data.should.have.properties(['lastKeepAlive','id','ip','status']);
+                done();
+            });
+        });
+
+        it('Select: wrong field', function(done) {
+            request(common.url)
+            .get("/agents/000?select=wrong_field")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1724);
+                done();
+            });
+        });
+
     });  // GET/agents/:agent_id
 
     describe('GET/agents/:agent_id/key', function() {

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -604,6 +604,22 @@ describe('Agents', function() {
                 });
         });
 
+        it('Filter: status', function (done) {
+            request(common.url)
+                .get("/agents/no_group?status=never%20connected")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['items','totalItems']);
+                    done();
+                });
+        });
+
         after(function (done) {
             request(common.url)
                 .delete("/agents/" + agent_id)


### PR DESCRIPTION
Hello team,

Currently, each filter in the GET/agents call is a parameter in the python function it executes:

https://github.com/wazuh/wazuh-api/blob/3f9abe9c59d898d054327959c23692d277c3c9c7/controllers/agents.js#L63-L76

This PR proposes a new way to process filters: using a dictionary where the key is the filter name and the value is the value to filter:

https://github.com/wazuh/wazuh-api/blob/d774dc4a40244fd6f73f241f7cd9a93332408479/controllers/agents.js#L53
https://github.com/wazuh/wazuh-api/blob/d774dc4a40244fd6f73f241f7cd9a93332408479/controllers/agents.js#L65-L80

This PR also adds new filters:
* Filter by group id in GET/agents API call:
```javascript
# curl -u foo:bar "localhost:55000/agents?pretty&group=default"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "default",
            "name": "perico",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node02",
            "dateAdd": "2018-06-04 15:17:28",
            "version": "Wazuh v3.2.4",
            "manager_host": "localhost.localdomain",
            "lastKeepAlive": "2018-06-06 09:47:56",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-693.el7.x86_64 |#1 SMP Tue Aug 22 21:09:27 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         },
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "default",
            "name": "agent2",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node01",
            "dateAdd": "2018-06-05 12:14:35",
            "version": "Wazuh v3.2.5",
            "manager_host": "localhost.localdomain",
            "lastKeepAlive": "2018-06-06 09:48:02",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-693.el7.x86_64 |#1 SMP Tue Aug 22 21:09:27 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "002"
         }
      ]
   }
}
```
* Filter by status in GET/agents/groups/:group_id API call
```javascript
# curl -u foo:bar "localhost:55000/agents/groups/default?pretty&status=Disconnected"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "default",
            "name": "perico",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node02",
            "dateAdd": "2018-06-04 15:17:28",
            "version": "Wazuh v3.2.4",
            "manager_host": "localhost.localdomain",
            "lastKeepAlive": "2018-06-06 09:47:56",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-693.el7.x86_64 |#1 SMP Tue Aug 22 21:09:27 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "001"
         },
         {
            "status": "Disconnected",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "group": "default",
            "name": "agent2",
            "mergedSum": "d9835ca466a5f6ede52e0684537f76bd",
            "ip": "any",
            "node_name": "node01",
            "dateAdd": "2018-06-05 12:14:35",
            "version": "Wazuh v3.2.5",
            "manager_host": "localhost.localdomain",
            "lastKeepAlive": "2018-06-06 09:48:02",
            "os": {
               "major": "7",
               "name": "CentOS Linux",
               "uname": "Linux |localhost.localdomain |3.10.0-693.el7.x86_64 |#1 SMP Tue Aug 22 21:09:27 UTC 2017 |x86_64",
               "platform": "centos",
               "version": "7",
               "codename": "Core",
               "arch": "x86_64"
            },
            "id": "002"
         }
      ]
   }
}
```

Best regards,
Marta