### PR TITLE
Fix error message when input validation check failed for select parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.3.0]
+
+### Fixed
+- Fixed error message when an invalid character was used with `select` parameter ([#98](https://github.com/wazuh/wazuh-api/pull/98)).
+
 ## [v3.2.4]
 
 There are no changes for Wazuh API in this version.

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -49,9 +49,11 @@ errors['ossec_key'] = 615;
 errors['616'] = "Param not valid. Valid characters: array of numbers";
 errors['array_numbers'] = 616;
 errors['timeframe_type'] = 617;
-errors['617'] = "Param not valid. Valid characters: [0-9]d|[0-9]h|[0-9]m|[0-9]s|0-9"
+errors['617'] = "Param not valid. Valid characters: [0-9]d|[0-9]h|[0-9]m|[0-9]s|0-9";
 errors['boolean'] = 618;
-errors['618'] = "Param not valid. Valid characters: true or false"
+errors['618'] = "Param not valid. Valid characters: true or false";
+errors['619'] = "Param not valid. Valid characters: a-z A-Z 0-9 space . , _";  // select
+errors['select_param'] = 619;
 
 errors['700'] = "File not found"
 

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -99,7 +99,7 @@ exports.search_param = function(param) {
 
 exports.select_param = function(param) {
     if (typeof param != 'undefined'){
-        var regex = /^[a-zA-Z0-9_\,]+$/;
+        var regex = /^[a-zA-Z0-9_\,\.]+$/;
         return regex.test(param);
     }
     else

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -186,6 +186,68 @@ describe('Agents', function() {
                 });
         });
 
+        it('Select: single field', function (done) {
+            request(common.url)
+                .get("/agents?select=lastKeepAlive")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['id', 'lastKeepAlive']);
+                    done();
+                });
+        });
+
+        it('Select: multiple fields', function (done) {
+            request(common.url)
+                .get("/agents?select=status,os.platform,os.version")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['id', 'status', 'os']);
+                    res.body.data.items[0].os.should.have.properties(['version','platform']);
+                    done();
+                });
+        });
+
+        it('Select: wrong field', function (done) {
+            request(common.url)
+                .get("/agents?select=wrong_field")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'message']);
+                    res.body.error.should.equal(1724);
+                    done();
+                });
+        });
+
+        it('Select: invalid character', function (done) {
+            request(common.url)
+                .get("/agents?select=invalidñcharacter")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(400)
+                .end(function (err, res) {
+
+                    res.body.should.have.properties(['error', 'message']);
+                    res.body.error.should.equal(619);
+                    done();
+                });
+        });
 
     });  // GET/agents
 
@@ -1020,7 +1082,7 @@ describe('Agents', function() {
                     done();
                 });
         });
-        
+
         it('Filter: older_than', function (done) {
             request(common.url)
                 .delete("/agents?older_than=1s")
@@ -1037,7 +1099,7 @@ describe('Agents', function() {
                     done();
                 });
         });
-        
+
     });  // DELETE/agents
 
 


### PR DESCRIPTION
Hello team,

When an invalid character was used with the `select` parameter, the following error was shown:

```javascript
# curl -u foo:bar "localhost:55000/agents?pretty&select=os.platform"
{
   "error": "Undefined error.",
   "message": "Undefined error..  Field: select"
}
```

This is not correct since the error is not being controlled correctly. This PR fixes that, showing the following message:

```javascript
# curl -u foo:bar "localhost:55000/agents?pretty&select=os.platform"
{
   "error": 619,
   "message": "Param not valid. Valid characters: a-z A-Z 0-9 space . , _.  Field: select"
}
```

Also, the character `.` has been added as valid to allow selecting fields such as `os.platform` and `os.version`:

```javascript
# curl -u foo:bar "localhost:55000/agents?select=status,os.platform,os.version&pretty"
{
   "error": 0,
   "data": {
      "totalItems": 2,
      "items": [
         {
            "status": "Active",
            "os": {
               "platform": "centos",
               "version": "7"
            },
            "id": "000"
         },
         {
            "status": "Active",
            "os": {
               "platform": "centos",
               "version": "7"
            },
            "id": "001"
         }
      ]
   }
}
```

Best regards,
Marta