### PR TITLE
Fix configure_api tries to remove preloaded_vars even if it doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [v3.3.0]
+## [v3.3.1]
+### Fixed
+- Fixed `configure_api` tries to remove `preloaded_vars` even if it doesn't exist. ([#106](https://github.com/wazuh/wazuh-api/pull/106))
 
+## [v3.3.0]
 ### Added
 - Filter by group in `GET/agents` API call. ([#97](https://github.com/wazuh/wazuh-api/pull/97))
 - Filter by status in `GET/agents/groups/:group_id` and `GET/agents/no_group` API calls. ([#97](https://github.com/wazuh/wazuh-api/pull/97))

--- a/scripts/configure_api.sh
+++ b/scripts/configure_api.sh
@@ -279,7 +279,9 @@ main () {
     fi
 
     print "\n### [Configuration changed] ###"
-    rm $PREDEF_FILE
+    if [ ! `isFile ${PREDEF_FILE}` = "${FALSE}" ]; then
+        rm $PREDEF_FILE
+    fi
     exit 0
 }
 


### PR DESCRIPTION
Hi team,

this PR fixes: https://github.com/wazuh/wazuh-api/issues/105.

Regards!