### PR TITLE
Fix purge filter in DELETE/agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.4.0]
+
+### Fixed
+- Fixed `purge` filter in `DELETE/agents` ([#122](https://github.com/wazuh/wazuh-api/pull/122))
+
 ## [v3.3.1]
 ### Changed
 - Output of `DELETE/agents`: Added attributes `total_affected_agents` and `total_failed_ids`. ([Wazuh #795](https://github.com/wazuh/wazuh/pull/795))

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -943,8 +943,8 @@ router.delete('/', function(req, res) {
     logger.debug(req.connection.remoteAddress + " DELETE /agents");
 
     var data_request = { 'function': 'DELETE/agents/', 'arguments': {}};
-    var filter_body = { 'ids': 'array_numbers'};
-    var filter_query = { 'older_than': 'timeframe_type', 'status': 'alphanumeric_param', 'purge': 'boolean' };
+    var filter_body = { 'ids': 'array_numbers', 'purge': 'boolean'};
+    var filter_query = { 'older_than': 'timeframe_type', 'status': 'alphanumeric_param', 'purge': 'empty_boolean' };
 
     if (!filter.check(req.body, filter_body, req, res))  // Filter with error
         return;
@@ -957,7 +957,12 @@ router.delete('/', function(req, res) {
         return;
     }
 
-    data_request['arguments']['purge'] = 'purge' in req.query && (req.query.purge == 'true' || req.query.purge == '');
+    if ('purge' in req.body && 'purge' in req.query) // the most restrictive wins
+        data_request['arguments']['purge'] = (req.query.purge == 'true' || req.query.purge == '') && (req.body.purge == 'true' || req.body.purge == true);
+    else if ('purge' in req.body)
+        data_request['arguments']['purge'] = (req.body.purge == 'true' || req.body.purge == true);
+    else if ('purge' in req.query)
+        data_request['arguments']['purge'] = (req.query.purge == 'true' || req.query.purge == '');
 
     if ('ids' in req.body)
         data_request['arguments']['list_agent_ids'] = req.body.ids;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -942,9 +942,9 @@ router.delete('/groups/:group_id', function(req, res) {
 router.delete('/', function(req, res) {
     logger.debug(req.connection.remoteAddress + " DELETE /agents");
 
-    var data_request = { 'function': 'DELETE/agents/', 'arguments': {} };
-    var filter_body = { 'ids': 'array_numbers', 'purge': 'boolean' };
-    var filter_query = { 'older_than': 'timeframe_type', 'status': 'alphanumeric_param'};
+    var data_request = { 'function': 'DELETE/agents/', 'arguments': {}};
+    var filter_body = { 'ids': 'array_numbers'};
+    var filter_query = { 'older_than': 'timeframe_type', 'status': 'alphanumeric_param', 'purge': 'boolean' };
 
     if (!filter.check(req.body, filter_body, req, res))  // Filter with error
         return;
@@ -957,7 +957,7 @@ router.delete('/', function(req, res) {
         return;
     }
 
-    data_request['arguments']['purge'] = 'purge' in req.body && (req.body['purge'] == true || req.body['purge'] == 'true');
+    data_request['arguments']['purge'] = 'purge' in req.query && (req.query['purge'] == true || req.query['purge'] == 'true');
 
     if ('ids' in req.body)
         data_request['arguments']['list_agent_ids'] = req.body.ids;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -957,7 +957,7 @@ router.delete('/', function(req, res) {
         return;
     }
 
-    data_request['arguments']['purge'] = 'purge' in req.query && (req.query['purge'] == true || req.query['purge'] == 'true');
+    data_request['arguments']['purge'] = 'purge' in req.query && (req.query.purge == 'true' || req.query.purge == '');
 
     if ('ids' in req.body)
         data_request['arguments']['list_agent_ids'] = req.body.ids;

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -145,7 +145,7 @@ exports.timeframe_type = function(param) {
 
 exports.boolean = function(n) {
     if (typeof n != 'undefined'){
-        var regex = /^true|false$/;
+        var regex = /^$|(^true|false$)/;
         return regex.test(n);
     }
     else

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -143,9 +143,18 @@ exports.timeframe_type = function(param) {
         return false;
 }
 
-exports.boolean = function(n) {
+exports.empty_boolean = function(n) {
     if (typeof n != 'undefined'){
         var regex = /^$|(^true|false$)/;
+        return regex.test(n);
+    }
+    else
+        return false;
+}
+
+exports.boolean = function(n) {
+    if (typeof n != 'undefined'){
+        var regex = /^true|false$/;
         return regex.test(n);
     }
     else


### PR DESCRIPTION
Hi team,

this PR fixes `purge` filter in `DELETE/agents` (issue https://github.com/wazuh/wazuh-api/issues/121).

## Sample

```
$ cat /var/ossec/etc/client.keys
001 agent001 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
002 agent002 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
003 agent003 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
004 agent004 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
005 agent005 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
006 agent006 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
007 agent007 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
008 agent008 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
009 agent009 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370
010 agent010 any aad3f2f3dc3ec3b2ffc76ecd0e74fbb8657bb09253abd0c9c06b1908328ae370

$ curl -u foo:bar -k -X DELETE "http://127.0.0.1:55000/agents?pretty&status=neverconnected&older_than=1s&purge=true"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "older_than": "1s",
      "affected_agents": [
         "001",
         "002",
         "003",
         "004",
         "005",
         "006",
         "007",
         "008",
         "009",
         "010"
      ],
      "total_affected_agents": 10
   }
}

$ cat /var/ossec/etc/client.keys
```

Regards,
Javi.