### PR TITLE
Installer option for disabling API service setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Improved agent registration/removal bash script ([#71](https://github.com/wazuh/wazuh-api/pull/71)).
 - New API request: `GET/agents/stats/distinct`. ([#115](https://github.com/wazuh/wazuh-api/pull/115))
-- New option on installer to prevent it from setting up a service.
+- Installer option for disabling API service setup. ([#129](https://github.com/wazuh/wazuh-api/pull/129))
 
 ### Changed
 - Move "Multiple DB requests" to `/experimental`. ([#124](https://github.com/wazuh/wazuh-api/pull/124))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Improved agent registration/removal bash script ([#71](https://github.com/wazuh/wazuh-api/pull/71)).
 - New API request: `GET/agents/stats/distinct`. ([#115](https://github.com/wazuh/wazuh-api/pull/115))
+- New option on installer to prevent it from setting up a service.
 
 ### Changed
 - Move "Multiple DB requests" to `/experimental`. ([#124](https://github.com/wazuh/wazuh-api/pull/124))

--- a/install_api.sh
+++ b/install_api.sh
@@ -147,7 +147,9 @@ show_info () {
 
 help() {
     echo "./install_api.sh [dependencies|download|dev]"
-    echo "./install_api.sh                Install API from current path"
+    echo "./install_api.sh <options>      Install API from current path"
+    echo "  Options:"
+    echo "  --no-service                  Do not install API service"
     echo "./install_api.sh dependencies   List dependencies"
     echo "./install_api.sh download       Download and install latest release (stable branch)"
     echo "./install_api.sh dev            Install API from current path in development mode"
@@ -180,6 +182,10 @@ previous_checks() {
         DOWNLOAD_PATH=$(url_latest_release "wazuh" "wazuh-api")
     else
         API_SOURCES="."  # empty argument
+    fi
+
+    if [ "X${arg}" == "X--no-service" ]; then   # do not install api service
+        NO_SERVICE="1"
     fi
 
     # Test root permissions
@@ -430,10 +436,15 @@ setup_api() {
     exec_cmd "chown root:ossec $APILOG_PATH"
     exec_cmd "chmod 660 $APILOG_PATH"
 
-    print "\nInstalling service."
-    echo "----------------------------------------------------------------"
-    exec_cmd_bash "$API_PATH/scripts/install_daemon.sh"
-    echo "----------------------------------------------------------------"
+    if [ -z "$NO_SERVICE" ]
+    then
+        print "\nInstalling service."
+        echo "----------------------------------------------------------------"
+        exec_cmd_bash "$API_PATH/scripts/install_daemon.sh"
+        echo "----------------------------------------------------------------"
+    else
+        print "\nSkipping service installation."
+    fi
 }
 
 main() {


### PR DESCRIPTION
This PR aims to add a new option in the installer:

```sh
./install_api.sh --no-service
```

This option disables the installation of the API service (Systemd or SysVinit).

If used, this option is confirmed with the following message:
```
Skipping service installation.
```