### PR TITLE
Remove hardcoded output of GET/manager/logs when generating documentation

### DIFF
--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -383,7 +383,7 @@ router.get('/stats/:node_id', cache(), function(req, res) {
  *
  * @apiDescription Returns the three last months of ossec.log.
  *
- * @apiExample {curl} Example usage*:
+ * @apiExample {curl} Example usage:
  *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/logs?offset=0&limit=5&pretty"
  *
  */

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -28,9 +28,6 @@ str_example_req = '**Example Request:**'
 str_example_res = '**Example Response:**'
 
 hardcoded_items = {
-        # GET - /manager/logs
-        'GetManagerLogs': {"error":0,"data":{"totalItems":16480,"items":["2016/07/15 09:33:49 ossec-syscheckd: INFO: Syscheck scan frequency: 3600 seconds","2016/07/15 09:33:49 ossec-syscheckd: INFO: Starting syscheck scan (forwarding database).","2016/07/15 09:33:49 ossec-syscheckd: INFO: Starting syscheck database (pre-scan).","2016/07/15 09:33:42 ossec-logcollector: INFO: Started (pid: 2832).","2016/07/15 09:33:42 ossec-logcollector: INFO: Monitoring output of command(360): df -P"]}},
-
         # GET - /manager/stats
         'GetManagerStats': {"error":0,"data":[{"hour":5,"firewall":0,"alerts":[{"times":4,"sigid":5715,"level":3},{"times":2,"sigid":1002,"level":2},{"...":"..."}],"totalAlerts":107,"syscheck":1257,"events":1483},{"...":"..."}]},
 


### PR DESCRIPTION
Hello team,

The output of GET/manager/logs was hardcoded in the script used to generate the documentation. The output of this API call changed but in the documentation, it remained the old way. This is why I've removed the hardcoded output from the script.

Best regards,
Marta