### PR TITLE
Update to api-register-agent.py

### DIFF
--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+###!/usr/bin/env python
 
 ###
 #  Python script for registering agents automatically with the API
-#  Copyright (C) 2017 Wazuh, Inc. All rights reserved.
+#  Copyright (C) 2018 Wazuh, Inc. All rights reserved.
 #  Wazuh.com
 #
 #  This program is a free software; you can redistribute it
@@ -14,6 +14,8 @@
 import os
 import json
 import sys
+import argparse, getpass
+import urlparse
 from subprocess import PIPE, Popen
 try:
     import requests
@@ -22,6 +24,8 @@ except Exception as e:
     print("No module 'requests' found. Install: pip install requests")
     sys.exit()
 
+OSSEC_CONF_PATH = '/var/ossec/etc/ossec.conf'
+verify = false
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)
@@ -52,11 +56,14 @@ def code_desc(http_status_code):
     return requests.status_codes._codes[http_status_code][0]
 
 
-def add_agent(agt_name, agt_ip=None):
-    if agt_ip:
-        status_code, response = req('post', 'agents', {'name': agt_name, 'ip': agt_ip})
-    else:
-        status_code, response = req('post', 'agents', {'name': agt_name})
+def add_agent(agt_name, agt_ip=None, force=False):
+    data = {}
+    data['name'] = agt_name
+    if agt_ip: 
+        data['ip'] = agt_ip
+    if force:
+       data['force'] = 0
+    status_code, response = req('post', 'agents', data)
 
     if status_code == 200 and response['error'] == 0:
         r_id  = response['data']['id']
@@ -68,26 +75,58 @@ def add_agent(agt_name, agt_ip=None):
         exit("ERROR - ADD AGENT:\n{0}\n{1}".format(code, msg))
 
 
+def set_group(agent_id, group_id):
+    status_code, response = req('put', "agents/{}/group/{}".format(agent_id, group_id))
+    if status_code != 200 or response['error'] != 0:
+        msg = json.dumps(response, indent=4, sort_keys=True)
+        code = "Status: {0} - {1}".format(status_code, code_desc(status_code))
+        exit("ERROR - SET AGENT GROUP:\n{0}\n{1}".format(code, msg))
+
+
 def import_key(agent_key):
     cmd = "/var/ossec/bin/manage_agents"
     std_out, std_err, r_code = execute([cmd, "-i", agent_key], "y\n\n")
     if r_code != 0:
         exit("ERROR - IMPORT KEY:{0}".format(std_err))
 
+
 def get_hostname():
     out, err, r_code = execute(["hostname"])
     if r_code != 0:
         exit("ERROR: Hostname unknown: {0}".format(e))
-
     hostname = out.strip()
-
     return hostname
+
 
 def execute(cmd_list, stdin=None):
     p = Popen(cmd_list, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     std_out, std_err = p.communicate(stdin)
     return_code = p.returncode
     return std_out, std_err, return_code
+
+
+def conf_exists():
+    if os.path.isfile(OSSEC_CONF_PATH): return True
+    return False
+
+
+def update_manager_host(manager_host):
+    #as the ossec.conf does not parse as valid xml, the method to replace the MANAGER_IP has to be slightly creative. 
+    #Read all file. 
+    with open(OSSEC_CONF_PATH, 'r') as file: 
+        filedata = file.read()
+    file.close()
+    filedata = filedata.split("\n")
+
+    #Write all file and replace the address portion. 
+    f = open(OSSEC_CONF_PATH, 'w')
+    for line in filedata: 
+        if "<address>" in line.lower() and "</address>" in line.lower():
+            #Copy until the end of the first address tag. This is to preserve tab format. 
+            line = line[0:line.find(">")+1]+ "{}</address>".format(manager_host)
+        f.write(line+"\n")
+    f.close()  
+
 
 def restart_ossec():
     cmd = "/var/ossec/bin/ossec-control"
@@ -102,24 +141,81 @@ def restart_ossec():
     if not restarted:
         exit("ERROR - RESTARTING OSSEC:{0}".format(std_err))
 
-if __name__ == "__main__":
-    # Configuration
-    base_url = 'http://10.0.0.1:55000'
-    auth = HTTPBasicAuth('foo', 'bar')
-    agent_name = "auto"
-    verify = False  # Use with self-signed certificates.
 
+def process(wazuh_url, agent_name, username, password, group=None, verify=False, force=False): 
+    auth = HTTPBasicAuth(username, password)
     print("Adding agent.")
-    if agent_name == "auto":
-        agent_name = get_hostname()
 
-    agent_id, agent_key = add_agent(agent_name)
+    agent_id, agent_key = add_agent(agt_name=agent_name,force=force)
     print("Agent '{0}' with ID '{1}' added.".format(agent_name, agent_id))
 
-    print("Importing authentication key.")
+    if group is not None: 
+        print ("Setting agent group to {}".format(group))
+	    set_group(agent_id, group)
+        print ("Agent group set")
 
+    print("Importing authentication key.")
     import_key(agent_key)
+    
+    print("Changing ossec.conf manager IP settings")
+    parsed_uri = urlparse.urlparse(base_url)
+    manager_host =  parsed_uri.netloc.split(':')[0]
+    update_manager_host(manager_host)
 
     print("Restarting.")
-
     restart_ossec()
+
+
+def main(): 
+    #main() only gets config params from the user via either cmd line args
+    #or interactive mode and passes them on to the process() function.  
+    interactive = True
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter, description="Run this script in interactive mode without providing any parameters: #python api-register-agent.py. You can also provide all configuration paramters via cmd parameters as follows. ")
+    parser.add_argument('-w', '--wazuh-url', help='The Wazuh API url. Required.')
+    parser.add_argument('-n', '--agent-name', help='The new agent name, typically the hostname. Required.')
+    parser.add_argument('-u', '--username', help='The Wazuh API username. Required.')
+    parser.add_argument('-p', '--password', help='The Wazuh API password. Required.')
+    parser.add_argument('-g', '--group', help='The Wazuh agent group. If unspecified, the default group will be used.')
+    parser.add_argument('-v', '--verify-cert', help='Certificate validation, keep False for self-signed certificates (if not using https, just ignore). Default False.', action ='store_true')
+    parser.add_argument('-f', '--force', help='Force replacement of agent. Useful when if agent IP is already registered. Default False.', action='store_true') 
+    args = parser.parse_args()
+
+    #if user fills up at least one cmd line argument, he does not want the interactive mode.
+    if (args.wazuh_url or args.agent_name or args.username or args.password):
+        #the required params for the cmd mode are url, agent name, username, password.
+        #if these not filled in show message and exit. 
+        interactive = False
+        if not (args.wazuh_url and args.agent_name and args.username and args.password):
+            exit ('The wazuh-url, agent-name, username and password parameters are mandatory. E.g. At a minimum: \n\n# python api-register-agent.py -w https://wazuh-api.myserver.com:5000 -n MyWebserver -u wazuh -p demo666\n\n Otherwise do not specify any params and use the interactive mode\n Use -h flag for help.')
+
+    if not conf_exists(): 
+        exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH)    
+ 
+    if interactive: #ask user for all details
+        agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
+        group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
+        base_url = raw_input("Enter the Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
+        verify = False
+        if base_url.lower().startswith("https"):
+            verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
+            if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): verify = True
+        if "55000" not in base_url: print ("*Warning*: Your URL does not seem to include the default port 55000. This is fine if your wazuh API is listening on a different port.")
+        if "http" not in base_url: print ("*Warning*: Your URL does not include a protocol (http:// or https://)")
+        username = raw_input ("Enter the Wazuh API username. Default:[wazuh]: ") or "wazuh"
+        password = getpass.getpass("Enter the Wazuh API Password and press ENTER: ")
+        force = False
+        force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or "n"
+        if force in ('y', 'Y', 'yes', 'Yes', 'YES'):
+            force = True
+    else: #get the details from the cmd args. 
+	agent_name = args.agent_name
+        group = args.group
+        base_url = args.wazuh_url
+        username = args.username
+        password = args.password
+        force = args.force
+        verify = args.verify_cert
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -171,6 +171,7 @@ def main():
     #main() only gets config params from the user via either cmd line args
     #or interactive mode and passes them on to the process() function.  
     interactive = True
+    global base_url, verify, auth
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter, description="Run this script in interactive mode without providing any parameters: #python api-register-agent.py. You can also provide all configuration paramters via cmd parameters as follows. ")
     parser.add_argument('-w', '--wazuh-url', help='The Wazuh API url. Required.')
     parser.add_argument('-n', '--agent-name', help='The new agent name, typically the hostname. Required.')
@@ -195,11 +196,9 @@ def main():
     if interactive: #ask user for all details
         agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
-        #base_url var is in global scope
         base_url = raw_input("Enter the Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
         verify = False
         if base_url.lower().startswith("https"):
-            #verify var is in global scope
             verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
             if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): verify = True
         if "55000" not in base_url: print ("*Warning*: Your URL does not seem to include the default port 55000. This is fine if your wazuh API is listening on a different port.")
@@ -219,7 +218,6 @@ def main():
         force = args.force
         verify = args.verify_cert
 
-    #auth var is in global scope
     auth = HTTPBasicAuth(username, password)
 
     register_agent(agent_name=agent_name, username=username, password=password, group=group, force=force)

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -142,7 +142,7 @@ def restart_ossec():
         exit("ERROR - RESTARTING OSSEC:{0}".format(std_err))
 
 
-def process(wazuh_url, agent_name, username, password, group=None, verify=False, force=False): 
+def process(wazuh_url, agent_name, username, password, group=None, force=False): 
     auth = HTTPBasicAuth(username, password)
     print("Adding agent.")
 
@@ -197,6 +197,7 @@ def main():
         base_url = raw_input("Enter the Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
         verify = False
         if base_url.lower().startswith("https"):
+            #verify var is in global scope
             verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
             if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): verify = True
         if "55000" not in base_url: print ("*Warning*: Your URL does not seem to include the default port 55000. This is fine if your wazuh API is listening on a different port.")
@@ -216,6 +217,7 @@ def main():
         force = args.force
         verify = args.verify_cert
 
+    process(wazuh_url=wazuh_url, agent_name=agent_name, username=username, password=password, group=group, force=force)
 
 if __name__ == "__main__":
     main()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -214,7 +214,7 @@ def main():
             force = False
 
     else: #get the details from the cmd args. 
-	agent_name = args.agent_name
+    agent_name = args.agent_name
         group = args.group
         base_url = args.wazuh_url
         username = args.username

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -203,6 +203,7 @@ def main():
         exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH))
  
     if interactive: #ask user for all details
+        print ("\nThis script also supports direct command line parameters. Use \"api-register-agent.py -h\" for more info\n\n") 
         agent_name = input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
         base_url = input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -24,7 +24,7 @@ except Exception as e:
 
 #Compatibility for both Python 2 and 3. 
 try: 
-    import urlparse
+    from urlparse import urlparse
 except ImportError: 
     from urllib.parse import urlparse
 from subprocess import PIPE, Popen

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -196,18 +196,23 @@ def main():
         agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
         base_url = raw_input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
-        verify = False
         if base_url.lower().startswith("https"):
             verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
-            if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): verify = True
+            if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): 
+                verify = True
+            else:
+                verify = False
+
         if "55000" not in base_url: print ("*Warning*: Your URL does not seem to include the default port 55000. This is fine if your wazuh API is listening on a different port.")
         if "http" not in base_url: print ("*Warning*: Your URL does not include a protocol (http:// or https://)")
         username = raw_input ("Enter the Wazuh API username. Default:[wazuh]: ") or "wazuh"
         password = getpass.getpass("Enter the Wazuh API Password and press ENTER: ")
-        force = False
         force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or False
         if force in ('y', 'Y', 'yes', 'Yes', 'YES'):
             force = True
+        else 
+            force = False
+
     else: #get the details from the cmd args. 
 	agent_name = args.agent_name
         group = args.group

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -32,7 +32,6 @@ auth=None
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)
-    print url
     try:
         requests.packages.urllib3.disable_warnings()
 
@@ -196,7 +195,7 @@ def main():
     if interactive: #ask user for all details
         agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
-        base_url = raw_input("Enter the Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
+        base_url = raw_input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
         verify = False
         if base_url.lower().startswith("https"):
             verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
@@ -206,7 +205,7 @@ def main():
         username = raw_input ("Enter the Wazuh API username. Default:[wazuh]: ") or "wazuh"
         password = getpass.getpass("Enter the Wazuh API Password and press ENTER: ")
         force = False
-        force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or "n"
+        force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or False
         if force in ('y', 'Y', 'yes', 'Yes', 'YES'):
             force = True
     else: #get the details from the cmd args. 
@@ -219,7 +218,6 @@ def main():
         verify = args.verify_cert
 
     auth = HTTPBasicAuth(username, password)
-
     register_agent(agent_name=agent_name, username=username, password=password, group=group, force=force)
 
 if __name__ == "__main__":

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -142,7 +142,7 @@ def restart_ossec():
         exit("ERROR - RESTARTING OSSEC:{0}".format(std_err))
 
 
-def process(wazuh_url, agent_name, username, password, group=None, force=False): 
+def process(api_url, agent_name, username, password, group=None, force=False): 
     auth = HTTPBasicAuth(username, password)
     print("Adding agent.")
 
@@ -158,7 +158,7 @@ def process(wazuh_url, agent_name, username, password, group=None, force=False):
     import_key(agent_key)
     
     print("Changing ossec.conf manager IP settings")
-    parsed_uri = urlparse.urlparse(base_url)
+    parsed_uri = urlparse.urlparse(api_url)
     manager_host =  parsed_uri.netloc.split(':')[0]
     update_manager_host(manager_host)
 
@@ -217,7 +217,7 @@ def main():
         force = args.force
         verify = args.verify_cert
 
-    process(wazuh_url=wazuh_url, agent_name=agent_name, username=username, password=password, group=group, force=force)
+    process(api_url=base_url, agent_name=agent_name, username=username, password=password, group=group, force=force)
 
 if __name__ == "__main__":
     main()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -1,4 +1,4 @@
-###!/usr/bin/env python
+#!/usr/bin/env python
 
 ###
 #  Python script for registering agents automatically with the API

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -203,7 +203,7 @@ def main():
         exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH))
  
     if interactive: #ask user for all details
-        print ("\nThis script also supports direct command line parameters. Use \"api-register-agent.py -h\" for more info\n") 
+        print ("\nThis script also supports direct command line parameters. Use \"python api-register-agent.py -h\" for more info\n") 
         agent_name = input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
         base_url = input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -15,7 +15,12 @@ import os
 import json
 import sys
 import argparse, getpass
-import urlparse
+
+#Compatibility for both Python 2 and 3. 
+try: 
+    import urlparse
+except ImportError: 
+    from urllib.parse import urlparse
 from subprocess import PIPE, Popen
 try:
     import requests
@@ -158,7 +163,7 @@ def register_agent(agent_name, username, password, group=None, force=False):
     import_key(agent_key)
     
     print("Changing ossec.conf manager IP settings")
-    parsed_uri = urlparse.urlparse(base_url)
+    parsed_uri = urlparse(base_url)
     manager_host =  parsed_uri.netloc.split(':')[0]
     update_manager_host(manager_host)
 

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -187,8 +187,8 @@ def main():
     parser.add_argument('-u', '--username', help='The Wazuh API username. Required.')
     parser.add_argument('-p', '--password', help='The Wazuh API password. Required.')
     parser.add_argument('-g', '--group', help='The Wazuh agent group. If unspecified, the default group will be used.')
-    parser.add_argument('-v', '--verify-cert', help='Certificate validation, keep False for self-signed certificates (if not using https, just ignore). Default False.', action ='store_true')
-    parser.add_argument('-f', '--force', help='Force replacement of agent. Useful when if agent IP is already registered. Default False.', action='store_true') 
+    parser.add_argument('-v', '--verify-cert', help='Certificate validation, keep False for self-signed certificates. Omit if not using https or using self-signed cert. Default unset.', action ='store_true')
+    parser.add_argument('-f', '--force', help='Force replacement of agent. Useful when if agent IP is already registered. Default unset.', action='store_true') 
     args = parser.parse_args()
 
     #if user fills up at least one cmd line argument, he does not want the interactive mode.

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -32,7 +32,7 @@ auth=None
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)
-
+    print url
     try:
         requests.packages.urllib3.disable_warnings()
 

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -210,7 +210,7 @@ def main():
         force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or False
         if force in ('y', 'Y', 'yes', 'Yes', 'YES'):
             force = True
-        else 
+        else:
             force = False
 
     else: #get the details from the cmd args. 

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -25,7 +25,7 @@ except Exception as e:
     sys.exit()
 
 OSSEC_CONF_PATH = '/var/ossec/etc/ossec.conf'
-verify = false
+verify = False
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -111,7 +111,7 @@ def get_hostname():
 
 
 def execute(cmd_list, stdin=None):
-    p = Popen(cmd_list, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    p = Popen(cmd_list, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding='utf8')
     std_out, std_err = p.communicate(stdin)
     return_code = p.returncode
     return std_out, std_err, return_code

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -26,6 +26,7 @@ except Exception as e:
 
 OSSEC_CONF_PATH = '/var/ossec/etc/ossec.conf'
 verify = False
+base_url = None
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)
@@ -142,7 +143,7 @@ def restart_ossec():
         exit("ERROR - RESTARTING OSSEC:{0}".format(std_err))
 
 
-def process(api_url, agent_name, username, password, group=None, force=False): 
+def process(agent_name, username, password, group=None, force=False): 
     auth = HTTPBasicAuth(username, password)
     print("Adding agent.")
 
@@ -158,7 +159,7 @@ def process(api_url, agent_name, username, password, group=None, force=False):
     import_key(agent_key)
     
     print("Changing ossec.conf manager IP settings")
-    parsed_uri = urlparse.urlparse(api_url)
+    parsed_uri = urlparse.urlparse(base_url)
     manager_host =  parsed_uri.netloc.split(':')[0]
     update_manager_host(manager_host)
 
@@ -194,6 +195,7 @@ def main():
     if interactive: #ask user for all details
         agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
+        #base_url var is in global scope
         base_url = raw_input("Enter the Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
         verify = False
         if base_url.lower().startswith("https"):
@@ -217,7 +219,7 @@ def main():
         force = args.force
         verify = args.verify_cert
 
-    process(api_url=base_url, agent_name=agent_name, username=username, password=password, group=group, force=force)
+    process(agent_name=agent_name, username=username, password=password, group=group, force=force)
 
 if __name__ == "__main__":
     main()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -141,11 +141,11 @@ def update_manager_host(manager_host):
 
 
 def restart_ossec():
-    cmd = "/var/ossec/bin/ossec-control".encode('utf-8')
-    std_out, std_err, r_code = execute([cmd, "restart".encode('utf-8')])
+    cmd = "/var/ossec/bin/ossec-control"
+    std_out, std_err, r_code = execute([cmd, "restart"])
     restarted = False
 
-    for line_output in std_out.split(os.linesep):
+    for line_output in std_out.split(os.linesep.encode('utf-8')):
         if "Completed." in line_output:
             restarted = True
             break

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -189,7 +189,7 @@ def main():
             exit ('The wazuh-url, agent-name, username and password parameters are mandatory. E.g. At a minimum: \n\n# python api-register-agent.py -w https://wazuh-api.myserver.com:5000 -n MyWebserver -u wazuh -p demo666\n\n Otherwise do not specify any params and use the interactive mode\n Use -h flag for help.')
 
     if not conf_exists(): 
-        exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH)    
+        exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH))
  
     if interactive: #ask user for all details
         agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -214,7 +214,7 @@ def main():
             force = False
 
     else: #get the details from the cmd args. 
-    agent_name = args.agent_name
+        agent_name = args.agent_name
         group = args.group
         base_url = args.wazuh_url
         username = args.username

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -146,7 +146,7 @@ def restart_ossec():
     restarted = False
 
     for line_output in std_out.split(os.linesep.encode('utf-8')):
-        if "Completed." in line_output:
+        if "Completed.".encode('utf-8') in line_output:
             restarted = True
             break
 

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -182,7 +182,7 @@ def main():
     interactive = True
     global base_url, verify, auth
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter, description="Run this script in interactive mode without providing any parameters: #python api-register-agent.py. You can also provide all configuration paramters via cmd parameters as follows. ")
-    parser.add_argument('-w', '--wazuh-url', help='The Wazuh API url. Required.')
+    parser.add_argument('-w', '--wazuh-url', help='The Wazuh API url. Also specify port. Required.')
     parser.add_argument('-n', '--agent-name', help='The new agent name, typically the hostname. Required.')
     parser.add_argument('-u', '--username', help='The Wazuh API username. Required.')
     parser.add_argument('-p', '--password', help='The Wazuh API password. Required.')

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -151,7 +151,7 @@ def process(wazuh_url, agent_name, username, password, group=None, verify=False,
 
     if group is not None: 
         print ("Setting agent group to {}".format(group))
-	    set_group(agent_id, group)
+        set_group(agent_id, group)
         print ("Agent group set")
 
     print("Importing authentication key.")

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -15,6 +15,12 @@ import os
 import json
 import sys
 import argparse, getpass
+try:
+    import requests
+    from requests.auth import HTTPBasicAuth
+except Exception as e:
+    print("No module 'requests' found. Install: pip install requests")
+    sys.exit()
 
 #Compatibility for both Python 2 and 3. 
 try: 
@@ -23,11 +29,10 @@ except ImportError:
     from urllib.parse import urlparse
 from subprocess import PIPE, Popen
 try:
-    import requests
-    from requests.auth import HTTPBasicAuth
-except Exception as e:
-    print("No module 'requests' found. Install: pip install requests")
-    sys.exit()
+   input = raw_input
+except NameError:
+   pass
+
 
 #Global scope variables
 OSSEC_CONF_PATH = '/var/ossec/etc/ossec.conf'
@@ -198,11 +203,11 @@ def main():
         exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH))
  
     if interactive: #ask user for all details
-        agent_name = raw_input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
-        group = raw_input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
-        base_url = raw_input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
+        agent_name = input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
+        group = input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
+        base_url = input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")
         if base_url.lower().startswith("https"):
-            verify = raw_input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
+            verify = input("Verify SSL certificate of API endpoint? (y/n) Default:[n]: ") or False
             if verify in ('y', 'Y', 'yes', 'Yes', 'YES'): 
                 verify = True
             else:
@@ -210,9 +215,9 @@ def main():
 
         if "55000" not in base_url: print ("*Warning*: Your URL does not seem to include the default port 55000. This is fine if your wazuh API is listening on a different port.")
         if "http" not in base_url: print ("*Warning*: Your URL does not include a protocol (http:// or https://)")
-        username = raw_input ("Enter the Wazuh API username. Default:[wazuh]: ") or "wazuh"
+        username = input ("Enter the Wazuh API username. Default:[wazuh]: ") or "wazuh"
         password = getpass.getpass("Enter the Wazuh API Password and press ENTER: ")
-        force = raw_input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or False
+        force = input("Force REPLACING of Agent if IP already exists? (y/n) Default:[n] ") or False
         if force in ('y', 'Y', 'yes', 'Yes', 'YES'):
             force = True
         else:

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -203,7 +203,7 @@ def main():
         exit("{} was not found. Do you have the wazuh-agent installed? See https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/index.html".format(OSSEC_CONF_PATH))
  
     if interactive: #ask user for all details
-        print ("\nThis script also supports direct command line parameters. Use \"api-register-agent.py -h\" for more info\n\n") 
+        print ("\nThis script also supports direct command line parameters. Use \"api-register-agent.py -h\" for more info\n") 
         agent_name = input("Please enter an agent Name. Default:[{}]: ".format(get_hostname())) or get_hostname()
         group = input("Enter the Wazuh Agent group you would like to put this Agent in. Default:[default]: ") or None
         base_url = input("Enter the base Wazuh API Url (E.g. https://200.10.10.10:55000, or https://wzh.myserver.com:55000): ")

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -141,8 +141,8 @@ def update_manager_host(manager_host):
 
 
 def restart_ossec():
-    cmd = "/var/ossec/bin/ossec-control"
-    std_out, std_err, r_code = execute([cmd, "restart"])
+    cmd = "/var/ossec/bin/ossec-control".encode('utf-8')
+    std_out, std_err, r_code = execute([cmd, "restart".encode('utf-8')])
     restarted = False
 
     for line_output in std_out.split(os.linesep):

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -24,9 +24,11 @@ except Exception as e:
     print("No module 'requests' found. Install: pip install requests")
     sys.exit()
 
+#Global scope variables
 OSSEC_CONF_PATH = '/var/ossec/etc/ossec.conf'
 verify = False
 base_url = None
+auth=None
 
 def req(method, resource, data=None):
     url = '{0}/{1}'.format(base_url, resource)
@@ -143,10 +145,8 @@ def restart_ossec():
         exit("ERROR - RESTARTING OSSEC:{0}".format(std_err))
 
 
-def process(agent_name, username, password, group=None, force=False): 
-    auth = HTTPBasicAuth(username, password)
+def register_agent(agent_name, username, password, group=None, force=False):  
     print("Adding agent.")
-
     agent_id, agent_key = add_agent(agt_name=agent_name,force=force)
     print("Agent '{0}' with ID '{1}' added.".format(agent_name, agent_id))
 
@@ -219,7 +219,10 @@ def main():
         force = args.force
         verify = args.verify_cert
 
-    process(agent_name=agent_name, username=username, password=password, group=group, force=force)
+    #auth var is in global scope
+    auth = HTTPBasicAuth(username, password)
+
+    register_agent(agent_name=agent_name, username=username, password=password, group=group, force=force)
 
 if __name__ == "__main__":
     main()

--- a/examples/api-register-agent.py
+++ b/examples/api-register-agent.py
@@ -97,7 +97,7 @@ def set_group(agent_id, group_id):
 
 def import_key(agent_key):
     cmd = "/var/ossec/bin/manage_agents"
-    std_out, std_err, r_code = execute([cmd, "-i", agent_key], "y\n\n")
+    std_out, std_err, r_code = execute([cmd.encode('utf-8'), "-i".encode('utf-8'), agent_key.encode('utf-8')], "y\n\n".encode('utf-8'))
     if r_code != 0:
         exit("ERROR - IMPORT KEY:{0}".format(std_err))
 
@@ -111,7 +111,7 @@ def get_hostname():
 
 
 def execute(cmd_list, stdin=None):
-    p = Popen(cmd_list, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding='utf8')
+    p = Popen(cmd_list, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     std_out, std_err = p.communicate(stdin)
     return_code = p.returncode
     return std_out, std_err, return_code


### PR DESCRIPTION
Changes
- Added interactive mode where the user can have suggested configuration parameters to input. 
- Added support for force, in order to force replace an agent having the same IP address or same Name. 
- update_manager_host(): The ossec.conf <address>MANAGER_IP</address> tag typically needing manual replacing in new agent installations is now automatically replaced by the script. This is replaced by taking the hostname/IP address when specifying the Wazuh API hostname.
- Works on Python2 and Python3. 
