### PR TITLE
Fix for '%' character error.

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -16,8 +16,7 @@ execute = require('../helpers/execute');
 templates = require('../helpers/request_templates');
 apicache  = require('apicache');
 cache     = apicache.middleware;
-wazuh_contro
-l = api_path + "/models/wazuh-api.py";
+wazuh_control = api_path + "/models/wazuh-api.py";
 
 var router = require('express').Router();
 var validator = require('../helpers/input_validation');

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -110,7 +110,12 @@ router.all('*',function(req, res) {
 
 // Router Errors
 router.use(function(err, req, res, next){
-    res_h.send(req, res, { error: 3, message: err.message || err }, 500)
+    logger.log("Internal Error");
+    if(err.stack)
+        logger.log(err.stack);
+    logger.log("Exiting...");
+
+    res_h.send(req, res, { error: 3 }, 500)
 });
 
 

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -16,7 +16,8 @@ execute = require('../helpers/execute');
 templates = require('../helpers/request_templates');
 apicache  = require('apicache');
 cache     = apicache.middleware;
-wazuh_control = api_path + "/models/wazuh-api.py";
+wazuh_contro
+l = api_path + "/models/wazuh-api.py";
 
 var router = require('express').Router();
 var validator = require('../helpers/input_validation');
@@ -110,14 +111,8 @@ router.all('*',function(req, res) {
 
 // Router Errors
 router.use(function(err, req, res, next){
-    logger.log("Internal Error");
-    if(err.stack)
-        logger.log(err.stack);
-    logger.log("Exiting...");
-
-    setTimeout(function(){ process.exit(1); }, 500);
+    res_h.send(req, res, { error: 3, message: err.message || err }, 500)
 });
-
 
 
 module.exports = router


### PR DESCRIPTION
Hi team,

This PR is for #172. The error caused by introducing `%` character has been solved. Now, the API process doesn't die when receives a '%' character in a API call.

Best regards,

Demetrio.