### PR TITLE
Fix for ppid filter in /syscollector/processes call

### DIFF
--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -286,6 +286,8 @@ router.get('/syscollector/processes', function (req, res) {
         data_request['arguments']['filters']['state'] = req.query.state;
     if ('pid' in req.query)
         data_request['arguments']['filters']['pid'] = req.query.pid;
+    if ('ppid' in req.query)
+        data_request['arguments']['filters']['ppid'] = req.query.ppid;
     if ('egroup' in req.query)
         data_request['arguments']['filters']['egroup'] = req.query.egroup;
     if ('euser' in req.query)

--- a/controllers/syscollector.js
+++ b/controllers/syscollector.js
@@ -224,6 +224,8 @@ router.get('/:agent_id/processes', function (req, res) {
         data_request['arguments']['filters']['state'] = req.query.state;
     if ('pid' in req.query)
         data_request['arguments']['filters']['pid'] = req.query.pid;
+    if ('ppid' in req.query)
+        data_request['arguments']['filters']['ppid'] = req.query.ppid;
     if ('egroup' in req.query)
         data_request['arguments']['filters']['egroup'] = req.query.egroup;
     if ('euser' in req.query)


### PR DESCRIPTION
Hi team,

`ppid` filter was not working properly and I fix it. I caught this error passing mocha tests. Below there is an output from this call:

```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/experimental/syscollector/processes?limit=2&offset=1&ppid=0&pretty"
{
   "error": 0,
   "data": {
      "totalItems": 6,
      "items": [
         {
            "tty": 0,
            "rgroup": "root",
            "sgroup": "root",
            "scan": {
               "id": 138130967,
               "time": "2018/10/15 08:24:56"
            },
            "resident": 0,
            "share": 0,
            "session": 0,
            "size": 0,
            "egroup": "root",
            "tgid": 2,
            "priority": 20,
            "fgroup": "root",
            "state": "S",
            "nlwp": 1,
            "nice": 0,
            "euser": "root",
            "pid": "2",
            "start_time": 5,
            "agent_id": "001",
            "vm_size": 0,
            "utime": 0,
            "ppid": 0,
            "name": "kthreadd",
            "pgrp": 0,
            "ruser": "root",
            "suser": "root",
            "processor": 0,
            "stime": 0
         }
      ]
   }
}
```