### PR TITLE
Error code for invalid characters in array names was added.

### DIFF
--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -56,6 +56,8 @@ errors['619'] = "Param not valid. Valid characters: a-z A-Z 0-9 space . , _";  /
 errors['select_param'] = 619;
 errors['yes_no_boolean'] = 620;
 errors['620'] = "Param not valid. Valid values: yes or no";
+errors['array_names'] = 621;
+errors['621'] = "Invalid character in parameters";
 
 errors['700'] = "File not found"
 


### PR DESCRIPTION
Hi team,

I got this output deleting groups because there isn't error code for array names:

```bash
# curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["my+group"]}' "http://127.0.0.1:55000/agents/groups?pretty"
{
   "error": "Undefined error.",
   "message": "Undefined error..  Field: ids"
}
```
I added an error code for this and now the output is:
```bash
# curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["my+group"]}' "http://127.0.0.1:55000/agents/groups?pretty"
{
   "error": 621,
   "message": "Invalid character in parameters.  Field: ids"
}
```
Best regards,

Demetrio.