### PR TITLE
API calls cluster/stats/remoted and cluster/stats/analysisd

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -367,6 +367,49 @@ router.get('/:node_id/stats/weekly', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /cluster/:node_id/stats/analysisd Get node node_id's stats
+ * @apiName GetManagerStatsCluster
+ * @apiGroup Stats
+ * 
+ * 
+ * @apiDescription Returns a summary of the current analysisd stats on the node.
+ *
+ * @apiExample {curl} Example usage*:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/analysisd/stats?pretty"
+ *
+ */
+router.get('/:node_id/stats/analysisd', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /cluster/:node_id/stats/analysisd");
+
+    req.apicacheGroup = "cluster";
+
+    var data_request = {'function': '/cluster/:node_id/stats/remoted', 'arguments': {}};
+    
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
+ * @api {get} /cluster/:node_id/stats/remoted Get node node_id's stats
+ * @apiName GetManagerStatsCluster
+ * @apiGroup Stats
+ *
+ * 
+ * @apiDescription Returns a summary of the current remoted stats on the node.
+ *
+ * @apiExample {curl} Example usage*:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/stats/remoted?pretty"
+ *
+ */
+router.get('/:node_id/stats/remoted', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /cluster/:node_id/stats/remoted");
+
+    req.apicacheGroup = "cluster";
+
+    var data_request = {'function': '/cluster/:node_id/stats/remoted', 'arguments': {}};
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {get} /cluster/:node_id/logs Get ossec.log from a specific node in cluster.
  * @apiName GetManagerLogsCluster
  * @apiGroup Logs

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -383,7 +383,7 @@ router.get('/:node_id/stats/analysisd', cache(), function(req, res) {
 
     req.apicacheGroup = "cluster";
 
-    var data_request = {'function': '/cluster/:node_id/stats/remoted', 'arguments': {}};
+    var data_request = {'function': '/cluster/:node_id/stats/analysisd', 'arguments': {}};
     
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -208,6 +208,27 @@ describe('Cluster', function () {
                 });
         });
 
+
+    }); // GET/cluster/nodes
+
+    describe('GET/cluster/:node_id/stats', function () {
+
+        it('Cluster stats', function (done) {
+            request(common.url)
+                .get("/cluster/stats")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    done();
+                });
+        });
+
         it('Unexisting node stats', function (done) {
             request(common.url)
                 .get("/cluster/unexisting_node/stats")
@@ -237,10 +258,20 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.totalItems.should.be.above(0);
-                    res.body.data.items.should.have.properties(['discarded_count', 'msg_sent', 'queue_size',
-                                                                'ctrl_msg_count', 'evt_count', 'tcp_sessions',
-                                                                'total_queue_size']);
+                    res.body.data.should.have.properties(['archives_queue_size', 'events_dropped',
+                                                          'rule_matching_queue_usage', 'alerts_queue_size',
+                                                          'event_queue_usage', 'events_edps', 'hostinfo_events_decoded',
+                                                          'syscollector_events_decoded', 'rootcheck_edps', 'events_processed',
+                                                          'firewall_queue_usage', 'alerts_queue_usage', 'firewall_queue_size',
+                                                          'alerts_written', 'firewall_written', 'syscheck_queue_size',
+                                                          'events_received', 'rootcheck_queue_usage', 'rootcheck_events_decoded',
+                                                          'rootcheck_queue_size', 'syscheck_edps', 'fts_written',
+                                                          'syscheck_queue_usage', 'other_events_edps', 'statistical_queue_usage',
+                                                          'hostinfo_edps', 'hostinfo_queue_usage', 'syscheck_events_decoded',
+                                                          'syscollector_queue_usage', 'archives_queue_usage', 'statistical_queue_size',
+                                                          'total_events_decoded', 'hostinfo_queue_size', 'syscollector_queue_size',
+                                                          'rule_matching_queue_size', 'other_events_decoded', 'event_queue_size',
+                                                          'syscollector_edps']);
                     done();
                 });
         });
@@ -257,14 +288,16 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.totalItems.should.be.above(0);
+                    
+                    res.body.data.should.have.properties(['discarded_count', 'msg_sent', 'queue_size',
+                                                          'ctrl_msg_count', 'evt_count', 'tcp_sessions',
+                                                          'total_queue_size']);
                     done();
                 });
         });
 
 
-
-    }); // GET/cluster/nodes
+    }); // GET/cluster/stats
 
 
     describe('GET/cluster/nodes/:node_name', function () {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -208,7 +208,7 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Unexisting node', function (done) {
+        it('Unexisting node stats', function (done) {
             request(common.url)
                 .get("/cluster/unexisting_node/stats")
                 .auth(common.credentials.user, common.credentials.password)
@@ -224,6 +224,44 @@ describe('Cluster', function () {
                     done();
                 });
         });
+
+        it('Analysisd stats', function (done) {
+            request(common.url)
+                .get("/cluster/:node_id/stats/analysisd")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.have.properties(['discarded_count', 'msg_sent', 'queue_size',
+                                                                'ctrl_msg_count', 'evt_count', 'tcp_sessions',
+                                                                'total_queue_size']);
+                    done();
+                });
+        });
+
+        it('Remoted stats', function (done) {
+            request(common.url)
+                .get("/cluster/:node_id/stats/remoted")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    done();
+                });
+        });
+
 
 
     }); // GET/cluster/nodes


### PR DESCRIPTION
Hi team,

I added this API calls for getting stats from `analysisd` and `remoted` from a cluster node:

```bash
$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/client/stats/analysisd?pretty"
{
   "error": 0,
   "data": {
      "archives_queue_size": 16384,
      "events_dropped": 0,
      "rule_matching_queue_usage": 0,
      "alerts_queue_size": 16384,
      "event_queue_usage": 0,
      "events_edps": 3,
      "hostinfo_events_decoded": 0,
      "syscollector_events_decoded": 0,
      "rootcheck_edps": 0,
      "events_processed": 15,
      "firewall_queue_usage": 0,
      "alerts_queue_usage": 0,
      "firewall_queue_size": 16384,
      "alerts_written": 0,
      "firewall_written": 0,
      "syscheck_queue_size": 16384,
      "events_received": 15,
      "rootcheck_queue_usage": 0,
      "rootcheck_events_decoded": 0,
      "rootcheck_queue_size": 16384,
      "syscheck_edps": 0,
      "fts_written": 0,
      "syscheck_queue_usage": 0,
      "other_events_edps": 3,
      "statistical_queue_usage": 0,
      "hostinfo_edps": 0,
      "hostinfo_queue_usage": 0,
      "syscheck_events_decoded": 0,
      "syscollector_queue_usage": 0,
      "archives_queue_usage": 0,
      "statistical_queue_size": 16384,
      "total_events_decoded": 15,
      "hostinfo_queue_size": 16384,
      "syscollector_queue_size": 16384,
      "rule_matching_queue_size": 16384,
      "other_events_decoded": 15,
      "event_queue_size": 16384,
      "syscollector_edps": 0
   }
}
```
```bash
$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/client/stats/remoted?pretty"  
{
   "error": 0,
   "data": {
      "discarded_count": 0,
      "msg_sent": 1334,
      "queue_size": 0,
      "ctrl_msg_count": 1334,
      "evt_count": 15379,
      "tcp_sessions": 0,
      "total_queue_size": 131072
   }
}
```

Best regards,

Demetrio.