### PR TITLE
Deny API calls in worker nodes

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,12 +166,17 @@ app.use(bodyParser.urlencoded({extended: true}));
 
 
 // check node type
+
 function check_type_node(){
-    var fs = require('fs');
-    var ossec_configuration = fs.readFileSync(config.ossec_path + "/etc/ossec.conf", "utf-8")
-    var parser = require('xml2json')
-    var xml_config = parser.toJson(ossec_configuration, {object: true})
-    var type_node = xml_config['ossec_config']['cluster']['node_type']
+    try {
+        var fs = require('fs');
+        var ossec_configuration = fs.readFileSync(config.ossec_path + "/etc/ossec.conf", "utf-8")
+        var parser = require('xml2json')
+        var xml_config = parser.toJson(ossec_configuration, {object: true})
+        var type_node = xml_config['ossec_config']['cluster']['node_type']
+    }catch(err){
+        var type_node = 'master'
+    }
 
     return type_node
 }

--- a/app.js
+++ b/app.js
@@ -164,6 +164,20 @@ if (config.ld_library_path.indexOf('api') != -1) {
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
+
+// check node type
+function check_type_node(){
+    var fs = require('fs');
+    var ossec_configuration = fs.readFileSync(config.ossec_path + "/etc/ossec.conf", "utf-8")
+    var parser = require('xml2json')
+    var xml_config = parser.toJson(ossec_configuration, {object: true})
+    var type_node = xml_config['ossec_config']['cluster']['node_type']
+
+    return type_node
+}
+
+var type_node = check_type_node()
+
 /**
  * Check Wazuh app version
  * Using: Header: "wazuh-app-version: X.Y.Z"
@@ -172,6 +186,10 @@ app.use(function(req, res, next) {
     var go_next = true;
     var app_version_header = req.get('wazuh-app-version');
     var regex_version = /^\d+\.\d+\.\d+$/i;
+
+    if(type_node == 'worker'){
+        res_h.bad_request(req, res, "API does not work in worker nodes.");
+    }
 
     if (typeof app_version_header != 'undefined'){
         if (!regex_version.test(app_version_header)){

--- a/app.js
+++ b/app.js
@@ -188,7 +188,7 @@ app.use(function(req, res, next) {
     var regex_version = /^\d+\.\d+\.\d+$/i;
 
     if(type_node == 'worker'){
-        res_h.bad_request(req, res, "803", "API calls in worker nodes are not allowed");
+        res_h.bad_request(req, res, "803");
     }
 
     if (typeof app_version_header != 'undefined'){

--- a/app.js
+++ b/app.js
@@ -188,7 +188,7 @@ app.use(function(req, res, next) {
     var regex_version = /^\d+\.\d+\.\d+$/i;
 
     if(type_node == 'worker'){
-        res_h.bad_request(req, res, "API does not work in worker nodes.");
+        res_h.bad_request(req, res, "803", "API calls in worker nodes are not allowed");
     }
 
     if (typeof app_version_header != 'undefined'){

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -65,7 +65,7 @@ errors['700'] = "File not found"
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";
 errors['801'] = "Wrong format for 'wazuh-app-version' header. Expected format: 'X.Y.Z'";
 errors['802'] = "Invalid 'wazuh-app-version' header";
-errors['803'] = "API does not work in worker nodes"
+errors['803'] = "API does not work in worker nodes";
 
 exports.description = function(n){
     if (n in errors)

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -65,7 +65,7 @@ errors['700'] = "File not found"
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";
 errors['801'] = "Wrong format for 'wazuh-app-version' header. Expected format: 'X.Y.Z'";
 errors['802'] = "Invalid 'wazuh-app-version' header";
-errors['803'] = "API does not work in worker nodes";
+errors['803'] = "Wazuh API is only available for master nodes";
 
 exports.description = function(n){
     if (n in errors)

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -65,6 +65,7 @@ errors['700'] = "File not found"
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";
 errors['801'] = "Wrong format for 'wazuh-app-version' header. Expected format: 'X.Y.Z'";
 errors['802'] = "Invalid 'wazuh-app-version' header";
+errors['803'] = "API does not work in worker nodes"
 
 exports.description = function(n){
     if (n in errors)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "htpasswd": "^2.3.4",
     "http-auth": "^3.0.1",
     "moment": "^2.15.0",
-    "rotating-file-stream": "^1.3.6"
+    "rotating-file-stream": "^1.3.6",
+    "xml2json": "^0.11.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi team,

I made some changes in `app.js` to deny API calls in worker nodes:
```bash
[root@localhost wazuh-api]# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty"
{"error":"803","message":"API does not work in worker nodes"}
```
Best regards,

Demetrio.