### PR TITLE
Fix healthcheck param validation

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -127,9 +127,9 @@ router.get('/healthcheck', cache(), function (req, res) {
     req.apicacheGroup = "cluster";
 
     var data_request = { 'function': '/cluster/healthcheck', 'arguments': {} };
-    var filters = { 'node': 'names'};
+    var filters = { 'node': 'names' };
 
-    if (!filter.check(req.params, filters, req, res))  // Filter with error
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
 
     data_request['arguments']['filter_node'] = req.query.node;


### PR DESCRIPTION
Hi team,

There was a error with filters in API call `cluster/healthcheck` (`node` is the only filter available):
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/healthcheck?pretty&nodos=master"
{
   "error": 0,
   "data": {
      "nodes": {
         "client": {
            "info": {
               "ip": "192.168.122.69",
               "version": "3.7.0",
               "type": "worker",
               "name": "client",
               "n_active_agents": 0
            },
            "status": {
               "last_sync_agentinfo": {
                  "date_start_master": "n/a",
                  "date_end_master": "n/a",
                  "total_agentinfo": 0
               },
               "sync_integrity_free": true,
               "last_sync_agentgroups": {
                  "date_end_master": "n/a",
                  "total_agentgroups": 0,
                  "date_start_master": "n/a"
               },
               "last_sync_integrity": {
                  "total_files": {
                     "shared": 0,
                     "missing": 1,
                     "extra_valid": 0,
                     "extra": 0
                  },
                  "date_end_master": "2018-10-23 09:10:34.53",
                  "date_start_master": "2018-10-23 09:10:33.40"
               },
               "last_keep_alive": "2018-10-23 09:10:28.610242",
               "sync_agentinfo_free": true,
               "sync_extravalid_free": true
            }
         },
         "master": {
            "info": {
               "ip": "192.168.122.143",
               "version": "3.7.0",
               "type": "master",
               "name": "master",
               "n_active_agents": 1
            }
         }
      },
      "n_connected_nodes": 2
   }
}
```
Validation was not working properly and I fixed it. Now, if you use a filter distinct to `node`:
```bash
curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/healthcheck?pretty&nodos=master"
{
   "error": 604,
   "message": "Filter error. Allowed filters: [ node ]  "
}
```

Best regards,

Demetrio.