### PR TITLE
Fix agents filter by os.name

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -28,6 +28,7 @@ var router = require('express').Router();
  * @apiParam {String} [older_than] Filters out disconnected agents for longer than specified. Time in seconds, '[n_days]d', '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never connected agents, uses the register date.
  * @apiParam {String} [os.platform] Filters by OS platform.
  * @apiParam {String} [os.version] Filters by OS version.
+ * @apiParam {String} [os.name] Filters by OS name.
  * @apiParam {String} [manager] Filters by manager hostname to which agents are connected.
  * @apiParam {String} [version] Filters by agents version.
  * @apiParam {String} [group] Filters by group of agents.
@@ -46,7 +47,8 @@ router.get('/', cache(), function(req, res) {
                          'os.version':'alphanumeric_param', 'manager':'alphanumeric_param',
                          'version':'alphanumeric_param', 'node': 'alphanumeric_param',
                          'older_than':'timeframe_type', 'group':'alphanumeric_param',
-                         'name': 'alphanumeric_param', 'ip': 'ips' };
+                         'name': 'alphanumeric_param', 'ip': 'ips',
+                         'os.name':'alphanumeric_param' };
     templates.array_request("/agents", req, res, "agents", {}, query_checks);
 })
 


### PR DESCRIPTION
Hi team,

This PR is for issue #192. I added `os.name` filter:
```bash
$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&os.name=CentOS+Linux"
{
   "error": 0,
   "data": {
      "items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "localhost.localdomain",
            "version": "Wazuh v3.7.0",
            "dateAdd": "2018-10-22 16:20:28",
            "status": "Active",
            "id": "000",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "ip": "127.0.0.1"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "agent001",
            "version": "Wazuh v3.6.1",
            "dateAdd": "2018-10-22 16:20:28",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "status": "Active",
            "id": "001",
            "lastKeepAlive": "2018-10-23 11:05:29",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "group": [
               "default"
            ],
            "ip": "192.168.122.58"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "agent002",
            "version": "Wazuh v3.7.0",
            "dateAdd": "2018-10-22 16:20:28",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "status": "Active",
            "id": "002",
            "lastKeepAlive": "2018-10-23 11:05:33",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "group": [
               "default"
            ],
            "ip": "192.168.122.19"
         }
      ],
      "totalItems": 3
   }
}
```

This filter only matches if the field `os.name` is the same that you are asking. I consider that using `q` filter (queries) you have more possibilities to filter, for example with `~` operator (`like` operator) because you can get the same response without writing the full name of the `OS`:
```bash
$ curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents?pretty&q=os.name~centos"    
{
   "error": 0,
   "data": {
      "items": [
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "localhost.localdomain",
            "version": "Wazuh v3.7.0",
            "ip": "127.0.0.1",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "status": "Active",
            "dateAdd": "2018-10-22 16:20:28",
            "lastKeepAlive": "9999-12-31 23:59:59",
            "id": "000"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.14.4.el7.x86_64 |#1 SMP Wed Sep 26 15:12:11 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "agent001",
            "version": "Wazuh v3.6.1",
            "ip": "192.168.122.58",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "group": [
               "default"
            ],
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "dateAdd": "2018-10-22 16:20:28",
            "lastKeepAlive": "2018-10-23 11:40:19",
            "id": "001"
         },
         {
            "os": {
               "arch": "x86_64",
               "codename": "Core",
               "major": "7",
               "name": "CentOS Linux",
               "platform": "centos",
               "uname": "Linux |localhost.localdomain |3.10.0-862.11.6.el7.x86_64 |#1 SMP Tue Aug 14 21:49:04 UTC 2018 |x86_64",
               "version": "7"
            },
            "name": "agent002",
            "version": "Wazuh v3.7.0",
            "ip": "192.168.122.19",
            "manager": "localhost.localdomain",
            "node_name": "master",
            "group": [
               "default"
            ],
            "mergedSum": "bcb219b9b009801f3b29eb9e00a6a88d",
            "status": "Active",
            "configSum": "ab73af41699f13fdd81903b5f23d8d00",
            "dateAdd": "2018-10-22 16:20:28",
            "lastKeepAlive": "2018-10-23 11:40:23",
            "id": "002"
         }
      ],
      "totalItems": 3
   }
}
```

Best regards,

Demetrio.