### PR TITLE
Disable API on workers

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,8 +171,8 @@ function check_type_node(){
     try {
         var fs = require('fs');
         var ossec_configuration = fs.readFileSync(config.ossec_path + "/etc/ossec.conf", "utf-8")
-        var parser = require('xml2json')
-        var xml_config = parser.toJson(ossec_configuration, {object: true})
+        var parser = require('xml2json-light')
+        var xml_config = parser.xml2json(ossec_configuration)
         var type_node = xml_config['ossec_config']['cluster']['node_type']
     }catch(err){
         var type_node = 'master'

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "http-auth": "^3.0.1",
     "moment": "^2.15.0",
     "rotating-file-stream": "^1.3.6",
-    "xml2json": "^0.11.2"
+    "xml2json-light": "^1.0.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi team,

`xml2json` library gave problems on `CentOS 6` and I changed this by `xml2json-light`. `xml2json-light` library hasn't got external dependencies as `xml2json`.

Best regards,

Demetrio.