### PR TITLE
Add an option to disable timeout in all API calls

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -19,7 +19,6 @@ cache     = apicache.middleware;
 wazuh_control = api_path + "/models/wazuh-api.py";
 
 var router = require('express').Router();
-var validator = require('../helpers/input_validation');
 var os = require("os");
 
 // Cache options
@@ -59,6 +58,12 @@ router.all("*", function(req, res, next) {
             delete req.query["pretty"];
         } else {
             req['pretty'] = false;
+        }
+        // wait for
+        if ("wait_for" in req.query) {
+            // Disable timeout in the current API call
+            execute.set_disable_timeout(true);
+            delete req.query["wait_for"];
         }
     }
 


### PR DESCRIPTION
Hello team,

This PR adds an option to disable timeout in API calls. An example:
```shellsession
# time curl -u foo:bar "localhost:55000/agents/001/upgrade?pretty&wait_for&force=1" -XPUT
{
   "error": 0,
   "data": "Upgrade procedure started"
}

real    0m58.279s
user    0m0.008s
sys     0m0.003s
# time curl -u foo:bar "localhost:55000/agents/001/upgrade?pretty&force=1" -XPUT
{
   "error": 1,
   "message": "Error executing internal command. Timeout exceeded (1s)."
}

real    0m1.036s
user    0m0.004s
sys     0m0.004s
```

This example has been done setting timeout to 1s here:
https://github.com/wazuh/wazuh-api/blob/e6b0c238f47f3a34f8659ebefce3ad703366d639/helpers/execute.js#L14

Best regards,
Marta