### PR TITLE
Disable API on worker nodes

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,25 +164,6 @@ if (config.ld_library_path.indexOf('api') != -1) {
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
 
-
-// check node type
-
-function check_type_node(){
-    try {
-        var fs = require('fs');
-        var ossec_configuration = fs.readFileSync(config.ossec_path + "/etc/ossec.conf", "utf-8")
-        var parser = require('xml2json-light')
-        var xml_config = parser.xml2json(ossec_configuration)
-        var type_node = xml_config['ossec_config']['cluster']['node_type']
-    }catch(err){
-        var type_node = 'master'
-    }
-
-    return type_node
-}
-
-var type_node = check_type_node()
-
 /**
  * Check Wazuh app version
  * Using: Header: "wazuh-app-version: X.Y.Z"
@@ -191,10 +172,6 @@ app.use(function(req, res, next) {
     var go_next = true;
     var app_version_header = req.get('wazuh-app-version');
     var regex_version = /^\d+\.\d+\.\d+$/i;
-
-    if(type_node == 'worker'){
-        res_h.bad_request(req, res, "803");
-    }
 
     if (typeof app_version_header != 'undefined'){
         if (!regex_version.test(app_version_header)){

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -23,6 +23,7 @@ try:
     from wazuh import Wazuh
     from wazuh.exception import WazuhException
     from wazuh.cluster.dapi import dapi
+    from wazuh.cluster.cluster import read_config
 except (ImportError, SyntaxError) as e:
     error = str(e)
     error_wazuh_package = -1
@@ -152,6 +153,13 @@ if __name__ == "__main__":
 
     # Main
     try:
+
+        cluster_config = read_config()
+        executable_name = "Wazuh API"
+        master_ip = cluster_config['nodes'][0]
+        if cluster_config['node_type'] != 'master' and cluster_config['disabled'] == 'no':
+            raise WazuhException(3019, {"EXECUTABLE_NAME": executable_name, "MASTER_IP": master_ip})
+
         before = time.time()
         wazuh = Wazuh(ossec_path=request['ossec_path'])
 


### PR DESCRIPTION
Hi team,

This PR is for disabling `Wazuh API` on worker nodes. I made this in `app.js` but I think that is better doing the changes in `wazuh-api.py` file.

Best regards,

Demetrio.