### PR TITLE
Fix bug when multiple select parameters are used in the API query

### DIFF
--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -105,9 +105,13 @@ exports.search_param_to_json = function (search_param){
 exports.select_param_to_json = function (select_param){
     var select = {"fields": []};
 
-    select_param.split(',').map(function(x) {
-        select['fields'].push(x);
-    });  
+    if (typeof select_param == 'string') {
+        select_param.split(',').map(function(x) {
+            select['fields'].push(x);
+        });
+    } else {
+        select['fields'] = select_param;
+    }
 
     return select
 }


### PR DESCRIPTION
Hello team,

This PR fixes #227.

When multiple `select` parameters are used in the API query, the API receives a list of values. The function to process the `select` parameter could only process string values but not lists. 

Best regards,
Marta