### PR TITLE
Remove xml2json-light library

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "htpasswd": "^2.3.4",
     "http-auth": "^3.0.1",
     "moment": "^2.15.0",
-    "rotating-file-stream": "^1.3.6",
-    "xml2json-light": "^1.0.6"
+    "rotating-file-stream": "^1.3.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi team,

`xml2json-light` library isn't necessary and I removed it.

Best regards,

Demetrio.