### PR TITLE
Fix bug when wazuh is installed in a custom directory

### DIFF
--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -153,6 +153,7 @@ if __name__ == "__main__":
 
     # Main
     try:
+        wazuh = Wazuh(ossec_path=request['ossec_path'])
 
         cluster_config = read_config()
         executable_name = "Wazuh API"
@@ -161,7 +162,6 @@ if __name__ == "__main__":
             raise WazuhException(3019, {"EXECUTABLE_NAME": executable_name, "MASTER_IP": master_ip})
 
         before = time.time()
-        wazuh = Wazuh(ossec_path=request['ossec_path'])
 
         if list_f:
             print_json(sorted(dapi.get_functions()))


### PR DESCRIPTION
Hello team,

When Wazuh was installed in a custom directory, such as `/etc/ossec`, the following error was shown when using the API:
```javascript
# curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/name/12893?pretty"
{
   "error": 3006,
   "message": "Error reading cluster configuration: Error getting configuration: [Errno 2] No such file or directory: '/var/ossec/etc/ossec.conf'"
}
```

A framework function (`read_config`) was being used before initializing the Wazuh object with the installation directory, so it was using the default value `/var/ossec`.

Best regards,
Marta