### PR TITLE
Fix typo in /agents/:agent_id/group/is_sync

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -501,7 +501,7 @@ router.get('/:agent_id/upgrade_result', function(req, res) {
 })
 
  /**
- * @api {get} /agents/:agent_id/group/is_sync Get sycn status of agent
+ * @api {get} /agents/:agent_id/group/is_sync Get sync status of agent
  * @apiName GetSync
  * @apiGroup Group
  *


### PR DESCRIPTION
Hi team,

I fixed a typo in `is_sync` function description.

Best regards,

Demetrio.