### PR TITLE
New call for adding multiple agents to a group

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -760,6 +760,40 @@ router.put('/:agent_id/group/:group_id', function(req, res) {
 
 
 /**
+ * @api {post} /agents/group/:group_id Add a list of agents to a group
+ * @apiName PostGroupAgents
+ * @apiGroup Groups
+ *
+ * @apiParam {Number} agent_id_list List of agents ID.
+ * @apiParam {String} group_id Group ID.
+ *
+ * @apiDescription Adds a list of agents to the specified group.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "http://localhost:55000/agents/group/dmz?pretty"
+ *
+ */
+router.post('/group/:group_id', function(req, res) {
+    logger.debug(req.connection.remoteAddress + " POST /agents/group/:group_id");
+
+    var data_request = {'function': 'POST/agents/group/:group_id', 'arguments': {}};
+    var filters = {'group_id':'names', 'ids':'array_numbers'}
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['group_id'] = req.params.group_id;
+    data_request['arguments']['agent_id_list'] = req.body.ids;
+
+    if ('ids' in req.body){
+        console.log('arguments ', data_request['arguments'])
+        execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    }else
+        res_h.bad_request(req, res, 604, "Missing field: 'ids'");
+})
+
+
+/**
  * @api {delete} /agents/groups Delete a list of groups
  * @apiName DeleteAgentsGroups
  * @apiGroup Delete


### PR DESCRIPTION
Hi team,

This PR is for issue #254. I added a new call for adding multiple agents to a group in the same call:

```bash
curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "http://localhost:55000/agents/group/dmz?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents assigned to group dmz",
      "affected_agents": [
         "001",
         "002"
      ]
   }
}
```

```bash
curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["003","007"]}' "http://localhost:55000/agents/group/dmz?pretty"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not assigned to group dmz",
      "failed_ids": [
         "007"
      ],
      "affected_agents": [
         "003"
      ]
   }
}

Best regards,

Demetrio.

```