### PR TITLE
API call for upgrading group configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,6 +163,8 @@ if (config.ld_library_path.indexOf('api') != -1) {
 // Body
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.text({type:"application/xml"}));
+
 
 /**
  * Check Wazuh app version

--- a/app.js
+++ b/app.js
@@ -211,6 +211,12 @@ app.use (function (err, req, res, next){
             msg = "Body: " + err.body;
         res_h.bad_request(req, res, "614", msg);
     }
+    else if (err == "PayloadTooLargeError: request entity too large"){
+        var msg = "";
+        if ('body' in err)
+            msg = "Body: " + err.body;
+        res_h.bad_request(req, res, "701", msg);
+    }
     else{
         logger.log("Internal Error");
         if(err.stack)

--- a/app.js
+++ b/app.js
@@ -163,7 +163,7 @@ if (config.ld_library_path.indexOf('api') != -1) {
 // Body
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
-app.use(bodyParser.text({type:"application/xml"}));
+app.use(bodyParser.text({type:"application/xml", limit:"1mb"}));
 
 
 /**

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -239,7 +239,7 @@ router.get('/groups/:group_id/configuration', cache(), function(req, res) {
  * @apiDescription Upload the group configuration (agent.conf).
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
+ *     curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
  *
  */
 router.post('/groups/:group_id/configuration', cache(), function(req, res) {

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -299,7 +299,7 @@ router.get('/groups/:group_id/files/:filename', cache(), function(req, res) {
         data_request['arguments']['type_conf'] = req.query.type;
 
     if ('format' in req.query) 
-        data_request['arguments']['format'] = req.query.format;
+        data_request['arguments']['return_format'] = req.query.format;
             
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -229,6 +229,39 @@ router.get('/groups/:group_id/configuration', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /agents/groups/:group_id/configuration Put configuration file (agent.conf) into a group
+ * @apiName PostAgentGroupConfiguration
+ * @apiGroup Groups
+ *
+ * @apiParam {String} group_id Group ID.
+ *
+ * @apiDescription Upload the group configuration (agent.conf).
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X POST -H 'Content-type: text/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
+ *
+ */
+router.post('/groups/:group_id/configuration', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " POST /agents/groups/:group_id/configuration");
+
+    req.apicacheGroup = "agents";
+
+    var data_request = {'function': '/agents/groups/:group_id/configuration', 'arguments': {}};
+    var filters = {'group_id': 'names'};
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['group_id'] = req.params.group_id;
+    data_request['arguments']['xml_file'] = req.rawBody;
+
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
+        return;
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {get} /agents/groups/:group_id/files/:filename Get a file in group
  * @apiName GetAgentGroupFile
  * @apiGroup Groups

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -252,6 +252,8 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
+    
+    if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
     data_request['arguments']['xml_file'] = req.body;
@@ -284,6 +286,8 @@ router.post('/groups/:group_id/files/:file_name', cache(), function(req, res) {
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
+
+    if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
     data_request['arguments']['xml_file'] = req.body;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -270,7 +270,8 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
  * @apiParam {String} [group_id] Group ID.
  * @apiParam {String} [file_name] Filename
  * @apiParam {String="conf","rootkit_files", "rootkit_trojans", "rcl"} [type] Type of file.
- *
+ * @apiParam {String="json","xml"} [format] Optional. Output format (JSON, XML).
+ * 
  * @apiDescription Returns the specified file belonging to the group parsed to JSON.
  *
  * @apiExample {curl} Example usage*:
@@ -291,12 +292,15 @@ router.get('/groups/:group_id/files/:filename', cache(), function(req, res) {
     data_request['arguments']['group_id'] = req.params.group_id;
     data_request['arguments']['filename'] = req.params.filename;
 
-    if (!filter.check(req.query, {'type': 'names'}, req, res))  // Filter with error
+    if (!filter.check(req.query, {'type': 'names', 'format': 'format'}, req, res))  // Filter with error
         return;
 
     if ('type' in req.query)
         data_request['arguments']['type_conf'] = req.query.type;
 
+    if ('format' in req.query) 
+        data_request['arguments']['format'] = req.query.format;
+            
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -256,8 +256,38 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
     data_request['arguments']['group_id'] = req.params.group_id;
     data_request['arguments']['xml_file'] = req.body;
 
-    if (!filter.check(req.query, filters, req, res))  // Filter with error
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
+ * @api {post} /agents/groups/:group_id/files/:file_name Upload file into a group
+ * @apiName PostAgentGroupFile
+ * @apiGroup Groups
+ *
+ * @apiParam {String} xml_file File. contents
+ * @apiParam {String} group_id Group ID.
+ * @apiParam {String} file_name File name.
+ *
+ * @apiDescription Upload a file to a group.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/files/agent.conf?pretty"
+ *
+ */
+router.post('/groups/:group_id/files/:file_name', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " POST /agents/groups/:group_id/files/:file_name");
+
+    req.apicacheGroup = "agents";
+
+    var data_request = {'function': 'POST/agents/groups/:group_id/files/:file_name', 'arguments': {}};
+    var filters = {'group_id': 'names', 'file_name': 'names'};
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
+
+    data_request['arguments']['group_id'] = req.params.group_id;
+    data_request['arguments']['xml_file'] = req.body;
+    data_request['arguments']['file_name'] = req.params.file_name;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -238,7 +238,7 @@ router.get('/groups/:group_id/configuration', cache(), function(req, res) {
  * @apiDescription Upload the group configuration (agent.conf).
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X POST -H 'Content-type: text/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
+ *     curl -u foo:bar -k -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
  *
  */
 router.post('/groups/:group_id/configuration', cache(), function(req, res) {
@@ -246,14 +246,14 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
 
     req.apicacheGroup = "agents";
 
-    var data_request = {'function': '/agents/groups/:group_id/configuration', 'arguments': {}};
+    var data_request = {'function': 'POST/agents/groups/:group_id/configuration', 'arguments': {}};
     var filters = {'group_id': 'names'};
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['xml_file'] = req.rawBody;
+    data_request['arguments']['xml_file'] = req.body;
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -229,10 +229,11 @@ router.get('/groups/:group_id/configuration', cache(), function(req, res) {
 })
 
 /**
- * @api {get} /agents/groups/:group_id/configuration Put configuration file (agent.conf) into a group
+ * @api {post} /agents/groups/:group_id/configuration Put configuration file (agent.conf) into a group
  * @apiName PostAgentGroupConfiguration
  * @apiGroup Groups
  *
+ * @apiParam {String} xml_file Configuration file.
  * @apiParam {String} group_id Group ID.
  *
  * @apiDescription Upload the group configuration (agent.conf).
@@ -789,40 +790,6 @@ router.put('/:agent_id/group/:group_id', function(req, res) {
     data_request['arguments']['replace'] = 'force_single_group' in req.query && req.query.replace != 'false' ? true : false;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
-})
-
-
-/**
- * @api {post} /agents/group/:group_id Add a list of agents to a group
- * @apiName PostGroupAgents
- * @apiGroup Groups
- *
- * @apiParam {Number} agent_id_list List of agents ID.
- * @apiParam {String} group_id Group ID.
- *
- * @apiDescription Adds a list of agents to the specified group.
- *
- * @apiExample {curl} Example usage:
- *     curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "http://localhost:55000/agents/group/dmz?pretty"
- *
- */
-router.post('/group/:group_id', function(req, res) {
-    logger.debug(req.connection.remoteAddress + " POST /agents/group/:group_id");
-
-    var data_request = {'function': 'POST/agents/group/:group_id', 'arguments': {}};
-    var filters = {'group_id':'names', 'ids':'array_numbers'}
-
-    if (!filter.check(req.params, filters, req, res))  // Filter with error
-        return;
-
-    data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['agent_id_list'] = req.body.ids;
-
-    if ('ids' in req.body){
-        console.log('arguments ', data_request['arguments'])
-        execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
-    }else
-        res_h.bad_request(req, res, 604, "Missing field: 'ids'");
 })
 
 

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -256,7 +256,7 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
     if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['xml_file'] = req.body;
+    data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
@@ -290,7 +290,7 @@ router.post('/groups/:group_id/files/:file_name', cache(), function(req, res) {
     if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['xml_file'] = req.body;
+    data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
     data_request['arguments']['file_name'] = req.params.file_name;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -760,6 +760,40 @@ router.put('/:agent_id/group/:group_id', function(req, res) {
 
 
 /**
+ * @api {post} /agents/group/:group_id Add a list of agents to a group
+ * @apiName PostGroupAgents
+ * @apiGroup Groups
+ *
+ * @apiParam {Number} agent_id_list List of agents ID.
+ * @apiParam {String} group_id Group ID.
+ *
+ * @apiDescription Adds a list of agents to the specified group.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "http://localhost:55000/agents/group/dmz?pretty"
+ *
+ */
+router.post('/group/:group_id', function(req, res) {
+    logger.debug(req.connection.remoteAddress + " POST /agents/group/:group_id");
+
+    var data_request = {'function': 'POST/agents/group/:group_id', 'arguments': {}};
+    var filters = {'group_id':'names', 'ids':'array_numbers'}
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['group_id'] = req.params.group_id;
+    data_request['arguments']['agent_id_list'] = req.body.ids;
+
+    if ('ids' in req.body){
+        console.log('arguments ', data_request['arguments'])
+        execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    }else
+        res_h.bad_request(req, res, 604, "Missing field: 'ids'");
+})
+
+
+/**
  * @api {delete} /agents/groups Delete a list of groups
  * @apiName DeleteAgentsGroups
  * @apiGroup Delete

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -38,7 +38,8 @@ apicache.options(cache_opt);
 router.post("*", function(req, res, next) {
     var content_type = req.get('Content-Type');
 
-    if (!content_type || !(content_type == 'application/json' || content_type == 'application/x-www-form-urlencoded')){
+    if (!content_type || !(content_type == 'application/json' || content_type == 'application/x-www-form-urlencoded'
+        || content_type == 'application/xml')){
         logger.debug(req.connection.remoteAddress + " POST " + req.path);
         res_h.bad_request(req, res, "607");
     }

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -60,6 +60,7 @@ errors['array_names'] = 621;
 errors['621'] = "Invalid character in parameters";
 
 errors['700'] = "File not found"
+errors['701'] = "Size of XML file is too long"
 
 // Headers
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -58,6 +58,7 @@ errors['yes_no_boolean'] = 620;
 errors['620'] = "Param not valid. Valid values: yes or no";
 errors['array_names'] = 621;
 errors['621'] = "Invalid character in parameters";
+errors['622'] = 'Invalid XML file'; 
 
 errors['700'] = "File not found"
 errors['701'] = "Size of XML file is too long"

--- a/helpers/files.js
+++ b/helpers/files.js
@@ -17,7 +17,7 @@ var moment = require('moment');
     Returns the file name
 */
 exports.tmp_file_creator = function(file_contents) {
-    random_file_name = '/var/ossec/tmp/' + moment().format();
+    random_file_name = '/var/ossec/tmp/api_group_conf_' + moment().unix() + '_' + Math.floor(Math.random() * Math.floor(1000)).toString();
 
     fs.writeFile(random_file_name, file_contents, (err) => {
         if (err) {

--- a/helpers/files.js
+++ b/helpers/files.js
@@ -1,0 +1,29 @@
+/**
+ * API RESTful for OSSEC
+ * Copyright (C) 2015-2019 Wazuh, Inc.All rights reserved.
+ * Wazuh.com
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+var fs = require('fs');
+var moment = require('moment');
+
+/*
+    Creates a temporary file with a random name containing file_contents.
+    Returns the file name
+*/
+exports.tmp_file_creator = function(file_contents) {
+    random_file_name = '/var/ossec/tmp/' + moment().format();
+
+    fs.writeFile(random_file_name, file_contents, (err) => {
+        if (err) {
+            throw err; 
+        }
+    });
+
+    return random_file_name;
+}

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -46,6 +46,17 @@ exports.check = function (query, filters, req, res){
     return true; // Filter OK
 }
 
+exports.check_xml = function(xml_string, req, res) {
+    var libxmljs = require('libxmljs');
+    try {
+        libxmljs.parseXml('<root>' + xml_string + '</root>');
+    } catch (error) {
+        res_h.bad_request(req, res, 622, error);
+        return false;
+    }
+    return true;
+}
+
 /*
  * filters = "-field1,field2"
  * Return:

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -91,3 +91,7 @@ exports.boolean = function(b) {
 exports.query_param = function(q) {
     return input_val(q, /[\w \d]+/);
 }
+
+exports.format = function(q) {
+    return input_val(q,/^xml|json$/)
+}

--- a/install_api.sh
+++ b/install_api.sh
@@ -333,6 +333,13 @@ setup_api_permissions () {
 
     # API users permissions
     exec_cmd "chmod 660 $API_PATH/configuration/auth/user"
+
+    # permissions for execute verify-agent-conf binary
+    exec_cmd "chgrp ossec $DEF_OSSDIR/bin/verify-agent-conf $DEF_OSSDIR/lib $DEF_OSSDIR/lib/libwazuhext.so"
+
+    # permissions for writing on /var/ossec/tmp
+    exec_cmd "chmod g+w $DEF_OSSDIR/tmp"
+
 }
 
 setup_api() {

--- a/install_api.sh
+++ b/install_api.sh
@@ -334,12 +334,6 @@ setup_api_permissions () {
     # API users permissions
     exec_cmd "chmod 660 $API_PATH/configuration/auth/user"
 
-    # permissions for execute verify-agent-conf binary
-    exec_cmd "chgrp ossec $DEF_OSSDIR/bin/verify-agent-conf $DEF_OSSDIR/lib $DEF_OSSDIR/lib/libwazuhext.so"
-
-    # permissions for writing on /var/ossec/tmp
-    exec_cmd "chmod g+w $DEF_OSSDIR/tmp"
-
 }
 
 setup_api() {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "htpasswd": "^2.3.4",
     "http-auth": "^3.0.1",
     "moment": "^2.15.0",
-    "rotating-file-stream": "^1.3.6"
+    "rotating-file-stream": "^1.3.6",
+    "libxmljs": "^0.19.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi team,

This PR  is for issue #245. I added a new call for upgrading group configurations. This is an example of this new call:

```bash
curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/dmz/configuration?pretty"
```

With the parameter `@agent.conf.xml` the content of this file will upgrade the group configuration (`dmz` in this example).

This feature is only available for upgrading `agent.conf` file, but this will be available for more files in the future.

It was necessary to change some permissions for execute our binary `verify-agent-conf` in `install_api.sh` script.

Best regards,

Demetrio.