### PR TITLE
Replace libxmljs by fast-xml-parser and bugfixes in custom install directories

### DIFF
--- a/helpers/files.js
+++ b/helpers/files.js
@@ -17,7 +17,7 @@ var moment = require('moment');
     Returns the file name
 */
 exports.tmp_file_creator = function(file_contents) {
-    random_file_name = '/var/ossec/tmp/api_group_conf_' + moment().unix() + '_' + Math.floor(Math.random() * Math.floor(1000)).toString();
+    random_file_name = config.ossec_path + '/tmp/api_group_conf_' + moment().unix() + '_' + Math.floor(Math.random() * Math.floor(1000)).toString();
 
     fs.writeFile(random_file_name, file_contents, (err) => {
         if (err) {

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -47,14 +47,14 @@ exports.check = function (query, filters, req, res){
 }
 
 exports.check_xml = function(xml_string, req, res) {
-    var libxmljs = require('libxmljs');
-    try {
-        libxmljs.parseXml('<root>' + xml_string + '</root>');
-    } catch (error) {
-        res_h.bad_request(req, res, 622, error);
+    var parser = require('fast-xml-parser');
+    var is_valid = parser.validate(xml_string);
+    if (is_valid === true) {
+        return true;
+    } else {
+        res_h.bad_request(req, res, 622, is_valid.err.msg);
         return false;
-    }
-    return true;
+    };
 }
 
 /*

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -18,9 +18,11 @@ try:
     new_path = '/var/ossec/framework'
     if not os_path.exists(new_path):
         current_path = path[0].split('/')
-        new_path = "/{0}/{1}/framework".format(current_path[1], current_path[2])
-    path.append(new_path)
+        new_path = "/{0}/{1}".format(current_path[1], current_path[2])
+        new_framework_path = "{}/framework".format(new_path)
+    path.append(new_framework_path)
     from wazuh import Wazuh
+    wazuh = Wazuh(ossec_path=new_path)
     from wazuh.exception import WazuhException
     from wazuh.cluster.dapi import dapi
     from wazuh.cluster.cluster import read_config

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -15,11 +15,11 @@ import time
 error_wazuh_package = 0
 exception_error = None
 try:
-    new_path = '/var/ossec/framework'
+    new_path = '/var/ossec'
     if not os_path.exists(new_path):
         current_path = path[0].split('/')
         new_path = "/{0}/{1}".format(current_path[1], current_path[2])
-        new_framework_path = "{}/framework".format(new_path)
+    new_framework_path = "{}/framework".format(new_path)
     path.append(new_framework_path)
     from wazuh import Wazuh
     wazuh = Wazuh(ossec_path=new_path)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.14.0",
     "htpasswd": "^2.3.4",
     "http-auth": "^3.0.1",
-    "libxmljs": "^0.19.5",
+    "fast-xml-parser": "^3.12.11",
     "moment": "^2.23.0",
     "rotating-file-stream": "^1.3.6",
     "userid": "^0.3.1"


### PR DESCRIPTION
Hello team,

This PR replaces `libxmljs` dependency by `fast-xml-parser` which is more lightweight and easier to install. It also fixes some bugs when running in custom directory installations.

Best regards,
Marta