### PR TITLE
Fix bug when there is an exception writing temporary files in api

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -256,8 +256,13 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
     if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
-
+    try {
+        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
+    } catch(err) {
+        res_h.bad_request(req, res, 702, err);
+        return;
+    }
+    
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 
@@ -290,7 +295,12 @@ router.post('/groups/:group_id/files/:file_name', cache(), function(req, res) {
     if (!filter.check_xml(req.body, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
+    try {
+        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
+    } catch(err) {
+        res_h.bad_request(req, res, 702, err);
+        return;
+    }
     data_request['arguments']['file_name'] = req.params.file_name;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -30,7 +30,7 @@ errors['605'] = "Param not valid. Date format: YYYYMMDD";  // Date
 errors['dates'] = 605;
 errors['606'] = "Param not valid. IP invalid";  // IP
 errors['ips'] = 606;  // IP
-errors['607'] = "Invalid content-type. POST requests should be 'application/json' or 'application/x-www-form-urlencoded'";  //
+errors['607'] = "Invalid content-type. POST requests should be 'application/json', 'application/x-www-form-urlencoded' or 'application/xml'";  //
 errors['608'] = "Param not valid. Path invalid. Valid characters: a-z, A-Z, 0-9, ., _, -, :, /, \\";  // Paths
 errors['paths'] = 608;
 errors['609'] = "Param not valid. Valid characters: a-z, A-Z, 0-9, ., _, -, +";  // Alphanumeric params
@@ -58,10 +58,11 @@ errors['yes_no_boolean'] = 620;
 errors['620'] = "Param not valid. Valid values: yes or no";
 errors['array_names'] = 621;
 errors['621'] = "Invalid character in parameters";
-errors['622'] = 'Invalid XML file'; 
 
-errors['700'] = "File not found"
-errors['701'] = "Size of XML file is too long"
+errors['700'] = "File not found";
+errors['701'] = "Size of XML file is too long";
+errors['702'] = "Could not write XML temporary file";
+errors['703'] = 'Invalid XML file'; 
 
 // Headers
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";

--- a/helpers/files.js
+++ b/helpers/files.js
@@ -19,7 +19,7 @@ var moment = require('moment');
 exports.tmp_file_creator = function(file_contents) {
     random_file_name = config.ossec_path + '/tmp/api_group_conf_' + moment().unix() + '_' + Math.floor(Math.random() * Math.floor(1000)).toString();
 
-    fs.writeFile(random_file_name, file_contents, (err) => {
+    fs.writeFileSync(random_file_name, file_contents, (err) => {
         if (err) {
             throw err; 
         }

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -52,7 +52,7 @@ exports.check_xml = function(xml_string, req, res) {
     if (is_valid === true) {
         return true;
     } else {
-        res_h.bad_request(req, res, 622, is_valid.err.msg);
+        res_h.bad_request(req, res, 703, is_valid.err.msg);
         return false;
     };
 }


### PR DESCRIPTION
Hello team,

This PR fixes a bug when the permissions in `/var/ossec/tmp` weren't correct:
```
WazuhAPI 2019-01-10 09:30:57 foo: Internal Error: uncaughtException
WazuhAPI 2019-01-10 09:30:57 foo: Error: EACCES: permission denied, open '/var/ossec/tmp/api_group_conf_1547112657_122'
WazuhAPI 2019-01-10 09:30:57 foo: Exiting..
```

Now the error is correctly returned by the API and it doesn't stop:
```json
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty"
{
   "error": 702,
   "message": "Could not write XML temporary file. Error: EACCES: permission denied, open '/var/ossec/tmp/api_group_conf_1547115265_583'"
}
```

Best regards,
Marta