### PR TITLE
Update installation script

### DIFF
--- a/install_api.sh
+++ b/install_api.sh
@@ -45,10 +45,10 @@ error_and_exit() {
 
     if [ "X${API_BACKUP}" == "Xyes" ]; then
         print "Backup directory: $API_PATH_BACKUP"
-        print "Restore backup:"
-        print "\t1. rm -r $API_PATH"
+        print "\t1. Save previous configuration: cp -rp $API_PATH_BACKUP/configuration $DEF_OSSDIR/tmp"
         print "\t2. Install API $API_OLD_VERSION"
-        print "\t3. Restore configuration: cp -rLfp $API_PATH_BACKUP/configuration $API_PATH/configuration"
+        print "\t3. Restore configuration: mv $DEF_OSSDIR/tmp/configuration $API_PATH/configuration"
+        print "\t4. Restart API"
     fi
 
     if [ -d "/root/wazuh-api-tmp" ]; then

--- a/install_api.sh
+++ b/install_api.sh
@@ -47,8 +47,8 @@ error_and_exit() {
         print "Backup directory: $API_PATH_BACKUP"
         print "Restore backup:"
         print "\t1. rm -r $API_PATH"
-        print "\t2. mv $API_PATH_BACKUP $API_PATH"
-        print "\t3. chown ossec:ossec $API_PATH"
+        print "\t2. Install API $API_OLD_VERSION"
+        print "\t3. Restore configuration: cp -p $API_PATH_BACKUP/configuration $API_PATH/configuration"
     fi
 
     if [ -d "/root/wazuh-api-tmp" ]; then
@@ -285,11 +285,24 @@ get_api () {
 
 backup_api () {
     if [ -e $API_PATH_BACKUP ]; then
-        exec_cmd "rm -rf $API_PATH_BACKUP"
+        exec_cmd "rm -rf $API_PATH_BACKUP/*"
+    else
+        exec_cmd "mkdir $API_PATH_BACKUP"
+        exec_cmd "chown root:ossec $API_PATH_BACKUP"
     fi
 
-    exec_cmd "cp -rLfp $API_PATH $API_PATH_BACKUP"
-    exec_cmd "chown root:root $API_PATH_BACKUP"
+    if [ -e $API_PATH/package.json ]; then
+        exec_cmd "cp -rLfp $API_PATH/package.json $API_PATH_BACKUP/package.json"
+    fi
+
+    if [ -d $API_PATH/configuration ]; then
+        exec_cmd "cp -rLfp $API_PATH/configuration $API_PATH_BACKUP/configuration"
+    fi
+
+    if [ -d $API_PATH/ssl ]; then
+        exec_cmd "cp -rLfp $API_PATH $API_PATH_BACKUP/ssl"
+    fi
+
     API_BACKUP='yes'
     API_OLD_VERSION=`cat $API_PATH_BACKUP/package.json | grep "version\":" | grep -P "\d+(?:\.\d+){0,2}\-*\w*" -o`
 }

--- a/install_api.sh
+++ b/install_api.sh
@@ -300,7 +300,7 @@ backup_api () {
     fi
 
     if [ -d $API_PATH/ssl ]; then
-        exec_cmd "cp -rLfp $API_PATH $API_PATH_BACKUP/ssl"
+        exec_cmd "cp -rLfp $API_PATH/ssl $API_PATH_BACKUP/ssl"
     fi
 
     API_BACKUP='yes'

--- a/install_api.sh
+++ b/install_api.sh
@@ -48,7 +48,7 @@ error_and_exit() {
         print "Restore backup:"
         print "\t1. rm -r $API_PATH"
         print "\t2. Install API $API_OLD_VERSION"
-        print "\t3. Restore configuration: cp -p $API_PATH_BACKUP/configuration $API_PATH/configuration"
+        print "\t3. Restore configuration: cp -rLfp $API_PATH_BACKUP/configuration $API_PATH/configuration"
     fi
 
     if [ -d "/root/wazuh-api-tmp" ]; then


### PR DESCRIPTION
Hi team,

I improved error messages when upgrading process fails and made some changes when old API is moved to a temporary directory (only needed files are copied).

This is the new message when API upgrade fails:
```bash
$ sudo ./install_api.sh 
### Wazuh API ###

Installing Wazuh API 3.8.0 from current directory.

Wazuh API is already installed (version 3.8.0). Do you want to update it? [y/n]: y

Updating API ['/var/ossec/api'].

Installing NodeJS modules.
Error executing command: 'cd /var/ossec/api && npm install --production'.

Backup directory: /var/ossec/~api
Restore backup:
	1. rm -r /var/ossec/api
	2. Install API 3.8.0
	3. Restore configuration: cp -p /var/ossec/~api/configuration /var/ossec/api/configuration

Exiting.
```

Best regards,

Demetrio.