### PR TITLE
Fix error when writing sync file

### DIFF
--- a/helpers/files.js
+++ b/helpers/files.js
@@ -19,11 +19,7 @@ var moment = require('moment');
 exports.tmp_file_creator = function(file_contents) {
     random_file_name = config.ossec_path + '/tmp/api_group_conf_' + moment().unix() + '_' + Math.floor(Math.random() * Math.floor(1000)).toString();
 
-    fs.writeFileSync(random_file_name, file_contents, (err) => {
-        if (err) {
-            throw err; 
-        }
-    });
+    fs.writeFileSync(random_file_name, file_contents);
 
     return random_file_name;
 }


### PR DESCRIPTION
Hello team!

This PR fixes an error when uploading an agent.conf file:

```
Send file error. Wazuh API error: 702 - Could not write XML temporary file. TypeError: Expected options to be either an object or a string, but got function instead
```

The error was in the function call `writeFileSync`. The third argument was expected to be an object containing options, not an error callback function.

Now it works properly:
```bash
root@ubuntu-bionic:/home/vagrant# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/configuration?pretty"
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}
root@ubuntu-bionic:/home/vagrant# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty"
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}
```

Best regards,
Dani