### PR TITLE
Limit request body size to 20KB

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,7 +163,7 @@ if (config.ld_library_path.indexOf('api') != -1) {
 // Body
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
-app.use(bodyParser.text({type:"application/xml", limit:"1mb"}));
+app.use(bodyParser.text({type:"application/xml", limit:"20kb"}));
 
 
 /**


### PR DESCRIPTION
Hello team,

The previous limit in the request body was 1mb, but since [the limit that `verify-agent-conf` binary can process is 20kb](https://github.com/wazuh/wazuh/blob/98288d310ffe6f718c4035ff060b7c3102a41cff/src/os_xml/os_xml_internal.h#L19), the API limit has been downgraded too:
```shellsession
# ls -lh
-rw-r--r-- 1 root    root     20K Jan 11 14:51 agent.conf.xml
-rw-r--r-- 1 root    root     25K Jan 11 14:52 bigagent.conf.xml
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @agent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty" -v
...
> Content-type: application/xml
> Content-Length: 20029
...
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}
* Connection #0 to host localhost left intact
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @bigagent.conf.xml "http://localhost:55000/agents/groups/webserver/files/agent.conf?pretty" -v
...
> Content-type: application/xml
> Content-Length: 25029
...
{"error":"701","message":"Size of XML file is too long"}
```

Best regards,
Marta