### PR TITLE
Escape XML contents in `<command>` tag

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -252,12 +252,14 @@ router.post('/groups/:group_id/configuration', cache(), function(req, res) {
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
+
+    var xml_escaped = require('../helpers/filters').escape_xml(req.body, req, res);
     
-    if (!filter.check_xml(req.body, req, res)) return;
+    if (!filter.check_xml(xml_escaped, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
     try {
-        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
+        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(xml_escaped);
     } catch(err) {
         res_h.bad_request(req, res, 702, err);
         return;
@@ -292,11 +294,13 @@ router.post('/groups/:group_id/files/:file_name', cache(), function(req, res) {
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
 
-    if (!filter.check_xml(req.body, req, res)) return;
+    var xml_escaped = require('../helpers/filters').escape_xml(req.body, req, res);
+
+    if (!filter.check_xml(xml_escaped, req, res)) return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
     try {
-        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(req.body);
+        data_request['arguments']['xml_file'] = require('../helpers/files').tmp_file_creator(xml_escaped);
     } catch(err) {
         res_h.bad_request(req, res, 702, err);
         return;

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -57,6 +57,24 @@ exports.check_xml = function(xml_string, req, res) {
     };
 }
 
+exports.escape_xml = function(xml_string, req, res) {
+    var xmlescape = require('xml-escape')
+    var xml_splitted = xml_string.split('<command>')
+    var to_replace = {}
+    for (x=1; x<xml_splitted.length; x++) {
+        command = xml_splitted[x].split('</command>')[0]
+        to_replace[command] = xmlescape(command)
+    }
+
+    var xml_escaped = xml_string
+    for (key in to_replace) {
+        var str_splitted = xml_escaped.split(key)
+        xml_escaped = str_splitted[0].concat(to_replace[key], str_splitted[1])
+    }
+
+    return xml_escaped
+}
+
 /*
  * filters = "-field1,field2"
  * Return:

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "body-parser": "^1.15.2",
     "cors": "^2.7.1",
     "express": "^4.14.0",
+    "fast-xml-parser": "^3.12.11",
     "htpasswd": "^2.3.4",
     "http-auth": "^3.0.1",
-    "fast-xml-parser": "^3.12.11",
     "moment": "^2.23.0",
     "rotating-file-stream": "^1.3.6",
-    "uid-number": "^0.0.6"
+    "uid-number": "^0.0.6",
+    "xml-escape": "^1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi team,

This PR is for issues [#260](https://github.com/wazuh/wazuh/issues/2060) and #282. Wazuh XML syntax allows predefined entities in XML (`<`, `>`, `&`, `'`, `"`) inside `<command>` tag, but this makes that `XML` syntax validators throws an error.

I fixed this by escaping this characters inside `<command>` tag. Below there are some examples of configurations with predefined entities in XML:
```bash
# cat test_xml
<agent_config>
<localfile>
    <log_format>full_command</log_format>
    <command>ok_users="^ABC$\|^DEF$"; cd /tmp; for i in $(ls); do if echo "$i" | grep -e "$ok_users" >/dev/null 2>&1; then continue; fi; if [ -d "$i/.ssh" ]; then if [ $(ls -a "$i/.ssh/" | wc -l) -gt 2 ]; then echo "SSH files found in $i"; fi; fi; done</command>
  <alias>test</alias>
  <frequency>300</frequency>
</localfile>
</agent_config>

# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @./test_xml "http://127.0.0.1:55000/agents/groups/default/configuration?pretty"
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}

# cat /var/ossec/etc/shared/default/agent.conf 
  <agent_config>
    <localfile>
      <log_format>full_command</log_format>
      <command>ok_users="^ABC$\|^DEF$"; cd /tmp; for i in $(ls); do if echo "$i" | grep -e "$ok_users" >/dev/null 2>&1; then continue; fi; if [ -d "$i/.ssh" ]; then if [ $(ls -a "$i/.ssh/" | wc -l) -gt 2 ]; then echo "SSH files found in $i"; fi; fi; done</command>
      <alias>test</alias>
      <frequency>300</frequency>
    </localfile>
  </agent_config>
```

```bash
# cat ampersand.xml
<agent_config>
  <localfile>
      <log_format>full_command</log_format>
      <command>/dev/null >&2</command>
  </localfile>
</agent_config>

# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @./ampersand.xml "http://127.0.0.1:55000/agents/groups/default/configuration?pretty"
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}

#  cat /var/ossec/etc/shared/default/agent.conf
  <agent_config>
    <localfile>
       <log_format>full_command</log_format>
       <command>/dev/null >&2</command>
    </localfile>
  </agent_config>
```

```bash
 # cat agent.conf
<agent_config>
  <!-- Shared agent configuration here -->
  <rootcheck> 
    <disabled>yes</disabled>
    <check_unixaudit>no</check_unixaudit>
    <check_files>yes</check_files>
    <check_trojans>no</check_trojans>
    <check_dev>yes</check_dev>
    <check_sys>yes</check_sys>
    <check_pids>yes</check_pids> 
    <check_ports>yes</check_ports>
    <check_if>yes</check_if>
    <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
  </rootcheck>
</agent_config>

# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @./agent.conf "http://127.0.0.1:55000/agents/groups/default/configuration?pretty"
{
   "error": 0,
   "data": "Agent configuration was updated successfully"
}

 # cat /var/ossec/etc/shared/default/agent.conf
  <agent_config>
    <!-- Shared agent configuration here -->
    <rootcheck>
      <disabled>yes</disabled>
      <check_unixaudit>no</check_unixaudit>
      <check_files>yes</check_files>
      <check_trojans>no</check_trojans>
      <check_dev>yes</check_dev>
      <check_sys>yes</check_sys>
      <check_pids>yes</check_pids>
      <check_ports>yes</check_ports>
      <check_if>yes</check_if>
      <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
    </rootcheck>
  </agent_config>
```

Best regards,

Demetrio.