### PR TITLE
Using chownSync and chmodSync. Added try/catch block too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Fixed bug missing some keys when showing group files in `GET/agents/groups/:group_id/files/:file_name` ([wazuh/wazuh#2223](https://github.com/wazuh/wazuh/pull/2223)).
 - Fixed bug showing rules variables names instead of its value in `GET/rules/:rule_id` ([wazuh/wazuh#2222](https://github.com/wazuh/wazuh/pull/2222)).
 - `GET/rules` API call returns the attributes for `<list>` and `<info>` ([wazuh/wazuh#2358](https://github.com/wazuh/wazuh/pull/2358)).
+- Fix bug setting file permissions when rotating API logs file ([#295](https://github.com/wazuh/wazuh-api/pull/295)).
 
 ## [v3.7.2]
 

--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -141,7 +141,10 @@ stream.on('rotated', function(filename) {
 
     // Prevents from crashing the service if the above instructions fail    
     } catch (error) {
-        
-        console.log(error.message || error)
+        try {
+            logger.error(error.message || error);
+        } catch (err) {
+            console.log(err.message || err)
+        }
     }
 });

--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -123,18 +123,25 @@ var stream = rfs(generator, {
 });
 
 stream.on('rotated', function(filename) {
-    // rotation job completed with success producing given filename
-    // setting correct permissions for generated files
-    logger.log("Rotated: " + filename);
-    fs.chmod(filename, 0o640);
-    fs.chmod(path.dirname(filename), 0o750);
-    fs.chmod(path.dirname(path.dirname(filename)), 0o750);
+    try {
+        // rotation job completed with success producing given filename
+        // setting correct permissions for generated files
+        logger.log("Rotated: " + filename);
+        fs.chmodSync(filename, 0o640);
+        fs.chmodSync(path.dirname(filename), 0o750);
+        fs.chmodSync(path.dirname(path.dirname(filename)), 0o750);
 
-    // if the API is running as root, set the user of the created files to ossec
-    if (!config.drop_privileges) {
-        fs.chown(filename, ossec_uid, ossec_gid);
-        fs.chown(path.dirname(filename), ossec_uid, ossec_gid);
-        fs.chown(path.dirname(path.dirname(filename)), ossec_uid, ossec_gid);
-        fs.chown(absolute_path_log, ossec_uid, ossec_gid);
+        // if the API is running as root, set the user of the created files to ossec
+        if (!config.drop_privileges) {
+            fs.chownSync(filename, ossec_uid, ossec_gid);
+            fs.chownSync(path.dirname(filename), ossec_uid, ossec_gid);
+            fs.chownSync(path.dirname(path.dirname(filename)), ossec_uid, ossec_gid);
+            fs.chownSync(absolute_path_log, ossec_uid, ossec_gid);
+        }
+
+    // Prevents from crashing the service if the above instructions fail    
+    } catch (error) {
+        
+        console.log(error.message || error)
     }
 });


### PR DESCRIPTION
Hi team,

- `fs.chmod` and `fs.chown` are async functions, this PR is using the sync alternatives.
- Added a try/catch block, this way we can prevent from crashing the service if the rotation fails.

Closes https://github.com/wazuh/wazuh-api/issues/280

Regards