### PR TITLE
Fix improper error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.8.1]
+
+### Fixed
+- Fixed improper error handling ([#296](https://github.com/wazuh/wazuh-api/pull/296))
+
 ## [v3.8.0]
 
 ### Added

--- a/app.js
+++ b/app.js
@@ -208,14 +208,11 @@ app.use (function (err, req, res, next){
     else if ('status' in err && err.status == 400){
         var msg = "";
         if ('body' in err)
-            msg = "Body: " + err.body;
+            msg = "Body is not correct.";
         res_h.bad_request(req, res, "614", msg);
     }
     else if (err == "PayloadTooLargeError: request entity too large"){
-        var msg = "";
-        if ('body' in err)
-            msg = "Body: " + err.body;
-        res_h.bad_request(req, res, "701", msg);
+        res_h.bad_request(req, res, "701");
     }
     else{
         logger.log("Internal Error");

--- a/helpers/execute.js
+++ b/helpers/execute.js
@@ -117,8 +117,13 @@ exports.exec = function(cmd, args, stdin, callback) {
 
                         if ( json_cmd.hasOwnProperty('message') ){
                             logger.error(json_cmd.message);
-                            if (typeof json_cmd.message === 'string')
-                                json_result.message = json_cmd.message.split(":", 1)[0];
+                            if ( json_result.error === 1000)
+                                json_result.message = "Internal error"
+                            else{
+                                if (typeof json_cmd.message === 'string')
+                                    json_result.message = json_cmd.message.split(":", 1)[0];
+                            }
+                            
 			}
                     }
                     else{

--- a/helpers/execute.js
+++ b/helpers/execute.js
@@ -118,7 +118,7 @@ exports.exec = function(cmd, args, stdin, callback) {
                         if ( json_cmd.hasOwnProperty('message') ){
                             logger.error(json_cmd.message);
                             if ( json_result.error === 1000)
-                                json_result.message = "Internal error"
+                                json_result.message = "Internal error";
                             else{
                                 if (typeof json_cmd.message === 'string')
                                     json_result.message = json_cmd.message.split(":", 1)[0];

--- a/helpers/execute.js
+++ b/helpers/execute.js
@@ -116,8 +116,9 @@ exports.exec = function(cmd, args, stdin, callback) {
                             json_result.data = json_cmd.data;
 
                         if ( json_cmd.hasOwnProperty('message') ){
-			    logger.error(json_cmd.message);
-                            json_result.message = json_cmd.message.split(":", 1);
+                            logger.error(json_cmd.message);
+                            if (typeof json_cmd.message === 'string')
+                                json_result.message = json_cmd.message.split(":", 1)[0];
 			}
                     }
                     else{


### PR DESCRIPTION
## Description
This PR closes #292, closes #293.

This fix makes the API log the error fully described in the api.log only when debug mode is enabled. This avoids showing private file paths or any other information that could be used by an attacker.

## Tests performed
Sent some request to an api in debug mode.
* Try internal error on console and see the api.log
```
# curl -u foo:bar "localhost:55000/cluster/node045/stats?pretty"{
   "error": 1000,
   "message": "Internal error"
}
```
```
## In api.log file...
WazuhAPI 2019-01-24 11:06:38 foo: totals() got an unexpected keyword argument 'node_id'
WazuhAPI 2019-01-24 11:06:38 foo: [::ffff:127.0.0.1] GET /cluster/node045/stats?pretty - 200 - error: '1000'.
```
* Try other errors
```
# curl -u foo:bar "localhost:55000/agents/groups/default/files/passwd?pretty"
{
   "error": 1006,
   "message": "File/directory does not exist"
}
```
```
## In api.log file...
WazuhAPI 2019-01-24 11:14:42 foo: File/directory does not exist: /var/ossec/etc/shared/default/passwd
WazuhAPI 2019-01-24 11:14:42 foo: [::ffff:127.0.0.1] GET /agents/groups/default/files/passwd?pretty - 200 - error: '1006'.
```
```
# curl -u foo:bar "localhost:55000/agents/groups/perere?pretty"
{
   "error": 1710,
   "message": "The group does not exist"
}
```
```
## In api.log file...
WazuhAPI 2019-01-24 11:15:31 foo: The group does not exist: perere
WazuhAPI 2019-01-24 11:15:31 foo: [::ffff:127.0.0.1] GET /agents/groups/perere?pretty - 200 - error: '1710'.
```
```
# curl -u foo:bar -k -X POST -d '{"name":"NewHost","ip""10.0.0.9"}' -H 'Content-Type:application/json' "http://127.0.0.1:55000/agents?pretty"
{"error":"614","message":"Invalid request. Body is not correct."}
```
```
## In api.log file...
WazuhAPI 2019-01-24 11:23:11 foo: [::ffff:127.0.0.1] POST /agents?pretty - 400 - error: '614'.
```