### PR TITLE
New mocha tests for worker nodes in cluster

### DIFF
--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,28 +550,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-        var ossec_conf
-
-        // save current ossec.conf
-        before(function (done) {
-            request(common.url)
-                .get("/cluster/master/files?path=etc/ossec.conf")
-                .auth(common.credentials.user, common.credentials.password)
-                .expect("Content-type", /json/)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) return done(err);
-
-                    res.body.should.have.properties(['error', 'data']);
-
-                    res.body.error.should.equal(0);
-                    res.body.data.should.be.an.string;
-                    
-                    ossec_conf = res.body.data
-
-                    done();
-                });
-        });
 
         before(function (done) {
 
@@ -585,6 +563,7 @@ describe('Cluster', function () {
             fs.unlinkSync(path.join(config.ossec_path, path_lists));
 
             done();
+
         });
 
         it('Upload rules', function(done) {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -20,6 +20,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 var path_rules = 'etc/rules/test_rules.xml'
 var path_decoders = 'etc/decoders/test_decoder.xml'
 var path_lists = 'etc/lists/test_list'
+var ossec_conf_content = null
 
 describe('Cluster', function () {
 
@@ -550,8 +551,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-        var ossec_conf
-
         // save current ossec.conf
         before(function (done) {
             request(common.url)
@@ -567,7 +566,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     
-                    ossec_conf = res.body.data
+                    ossec_conf_content = res.body.data
 
                     done();
                 });
@@ -782,6 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
+                    res.body.shoud.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,6 +550,29 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
+        var ossec_conf
+
+        // save current ossec.conf
+        before(function (done) {
+            request(common.url)
+                .get("/cluster/master/files?path=etc/ossec.conf")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.be.an.string;
+                    
+                    ossec_conf = res.body.data
+
+                    done();
+                });
+        });
+
         it('Upload rules', function(done) {
             request(common.url)
             .post("/cluster/master/files?path=" + path_rules)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -821,7 +821,7 @@ describe('Cluster', function () {
 
                     res.body.should.have.properties(['error', 'data']);
 
-                    es.body.error.should.equal(0);
+                    res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     res.body.data.should.equal(ossec_conf_content_master)
 
@@ -840,7 +840,7 @@ describe('Cluster', function () {
 
                     res.body.should.have.properties(['error', 'data']);
 
-                    es.body.error.should.equal(0);
+                    res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     res.body.data.should.equal(ossec_conf_content_worker)
 

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,22 +550,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-
-        before(function (done) {
-
-            var config = require('../configuration/config')
-            var path = require('path')
-            var fs = require('fs')
-
-            // delete test files
-            fs.unlinkSync(path.join(config.ossec_path, path_rules));
-            fs.unlinkSync(path.join(config.ossec_path, path_decoders));
-            fs.unlinkSync(path.join(config.ossec_path, path_lists));
-
-            done();
-
-        });
-
         it('Upload rules', function(done) {
             request(common.url)
             .post("/cluster/master/files?path=" + path_rules)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -781,7 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.should.equal(ossec_conf_content)
+                    res.body.data.should.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1049,7 +1049,48 @@ describe('Cluster', function () {
 
     });  // GET/cluster/:node_id/files
 
-    describe('/cluster/:node_id/configuration/validation', function() {
+    describe('/cluster/:node_id/configuration/validation (OK)', function() {
+
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+        it('Request validation (worker)', function (done) {
+            request(common.url)
+                .get("/cluster/worker/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+                    done();
+                });
+        });
+
+    });  // GET/cluster/:node_id/configuration/validation (OK)
+
+    describe('/cluster/:node_id/configuration/validation (KO)', function() {
 
         // upload corrupted ossec.conf in worker (semantic)
         before(function (done) {
@@ -1092,9 +1133,9 @@ describe('Cluster', function () {
               });
         });
 
-        it('Request validation (master)', function (done) {
+        it('Request validation (worker)', function (done) {
             request(common.url)
-                .get("/cluster/master/configuration/validation")
+                .get("/cluster/worker/configuration/validation")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -1104,16 +1145,17 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.should.have.properties(['status']);
-                    res.body.data.status.should.equal('OK');
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
 
                     done();
                 });
         });
 
-        it('Request validation (worker)', function (done) {
+        it('Request validation (all nodes)', function (done) {
             request(common.url)
-                .get("/cluster/worker/configuration/validation")
+                .get("/cluster/configuration/validation")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -781,7 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.shoud.equal(ossec_conf_content)
+                    res.body.should.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -452,7 +452,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.have.properties(['nodes', 'n_connected_nodes']);
 
-                    res.body.data.n_connected_nodes.should.be.above(1)
+                    res.body.data.n_connected_nodes.should.be.above(0)
 
                     res.body.data.nodes.should.have.properties([expected_name_worker, expected_name_master]);
 
@@ -511,7 +511,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.have.properties(['nodes', 'n_connected_nodes']);
 
-                    res.body.data.n_connected_nodes.should.be.above(1)
+                    res.body.data.n_connected_nodes.should.be.above(0)
 
                     res.body.data.nodes.should.have.properties([expected_name_worker]);
 


### PR DESCRIPTION
Hi team,

I wrote new mocha tests for cluster (manager too). Tests for checking new features in worker nodes were added.

Below there is the result of executing cluster mocha tests:

```bash
# mocha test/test_cluster.js     


  Cluster
    GET/cluster/nodes
      ✓ Request (512ms)
      ✓ Pagination (239ms)
      ✓ Retrieve all elements with limit=0 (216ms)
      ✓ Sort (232ms)
      ✓ Search (247ms)
      ✓ Filters: type (234ms)
      ✓ Filters: invalid type (249ms)
      ✓ Select (232ms)
      ✓ Select 2 (269ms)
      ✓ Wrong select (250ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (233ms)
      ✓ Unexisting node stats (278ms)
      ✓ Analysisd stats (262ms)
      ✓ Remoted stats (243ms)
    GET/cluster/nodes/:node_name
      ✓ Request (217ms)
      ✓ Request wrong name (247ms)
    GET/cluster/status
      ✓ Request (257ms)
    GET/cluster/config
      ✓ Request (223ms)
    GET/cluster/healthcheck
      ✓ Request (211ms)
      ✓ Filter: node name (235ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (199ms)
      ✓ Upload ossec.conf (worker) (293ms)
      ✓ Upload rules (232ms)
      ✓ Upload decoder (237ms)
      ✓ Upload list (224ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (233ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (245ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (230ms)
    /cluster/:node_id/files
      ✓ Request ossec.conf (master) (237ms)
      ✓ Request ossec.conf (worker) (248ms)
      ✓ Request rules (227ms)
      ✓ Request decoders (352ms)
      ✓ Request lists (235ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (243ms)
      ✓ Request file from unexisting node (232ms)
    /cluster/:node_id/configuration/validation (all nodes OK)
      ✓ Request validation (master) (489ms)
      ✓ Request validation (worker) (488ms)
      ✓ Request validation (all nodes) (454ms)
    /cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (206ms)
      ✓ Request validation (worker) (472ms)
      ✓ Request validation (all nodes) (419ms)
    /cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (372ms)
      ✓ Request validation (worker) (244ms)
      ✓ Request validation (all nodes) (437ms)
    /cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (247ms)
      ✓ Request validation (worker) (254ms)
      ✓ Request validation (all nodes) (251ms)
    PUT/cluster/:node_id/restart
      ✓ Request (master) (241ms)
      ✓ Request (worker) (460ms)


  57 passing (17s)

```

```bash
# mocha test/test_manager.js 


  Manager
    GET/manager/status
      ✓ Request (565ms)
    GET/manager/info
      ✓ Request (239ms)
    GET/manager/configuration
      ✓ Request (304ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (648ms)
      ✓ Errors: Invalid Section (389ms)
      ✓ Filters: Section - field (212ms)
      ✓ Errors: Invalid field (296ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (216ms)
      ✓ Filters: date (248ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (219ms)
    GET/manager/stats/weekly
      ✓ Request (222ms)
    GET/manager/stats/analysisd
      ✓ Request (362ms)
    GET/manager/stats/remoted
      ✓ Request (357ms)
    GET/manager/logs
      ✓ Request (289ms)
      ✓ Pagination (286ms)
      ✓ Retrieve all elements with limit=0 (317ms)
      ✓ Sort (425ms)
      ✓ SortField (357ms)
      ✓ Search (338ms)
      ✓ Filters: type_log (282ms)
      ✓ Filters: category (249ms)
      ✓ Filters: type_log and category (391ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (551ms)
    PUT/manager/restart
      ✓ Request (295ms)
    POST/manager/files
      ✓ Upload ossec.conf (266ms)
      ✓ Upload rules (250ms)
      ✓ Upload decoder (237ms)
      ✓ Upload list (276ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
    /manager/files
      ✓ Request ossec.conf (334ms)
      ✓ Request rules (253ms)
      ✓ Request decoders (265ms)
      ✓ Request lists (250ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (226ms)


  47 passing (11s)
```

Best regards,

Demetrio.