### PR TITLE
Update mocha test (manager)

### DIFF
--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,28 +550,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-        var ossec_conf
-
-        // save current ossec.conf
-        before(function (done) {
-            request(common.url)
-                .get("/cluster/master/files?path=etc/ossec.conf")
-                .auth(common.credentials.user, common.credentials.password)
-                .expect("Content-type", /json/)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) return done(err);
-
-                    res.body.should.have.properties(['error', 'data']);
-
-                    res.body.error.should.equal(0);
-                    res.body.data.should.be.an.string;
-                    
-                    ossec_conf = res.body.data
-
-                    done();
-                });
-        });
 
         before(function (done) {
 
@@ -585,6 +563,7 @@ describe('Cluster', function () {
             fs.unlinkSync(path.join(config.ossec_path, path_lists));
 
             done();
+
         });
 
         it('Upload rules', function(done) {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -20,6 +20,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 var path_rules = 'etc/rules/test_rules.xml'
 var path_decoders = 'etc/decoders/test_decoder.xml'
 var path_lists = 'etc/lists/test_list'
+var ossec_conf_content = null
 
 describe('Cluster', function () {
 
@@ -550,8 +551,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-        var ossec_conf
-
         // save current ossec.conf
         before(function (done) {
             request(common.url)
@@ -567,7 +566,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     
-                    ossec_conf = res.body.data
+                    ossec_conf_content = res.body.data
 
                     done();
                 });
@@ -782,6 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
+                    res.body.shoud.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,6 +550,29 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
+        var ossec_conf
+
+        // save current ossec.conf
+        before(function (done) {
+            request(common.url)
+                .get("/cluster/master/files?path=etc/ossec.conf")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.be.an.string;
+                    
+                    ossec_conf = res.body.data
+
+                    done();
+                });
+        });
+
         it('Upload rules', function(done) {
             request(common.url)
             .post("/cluster/master/files?path=" + path_rules)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -821,7 +821,7 @@ describe('Cluster', function () {
 
                     res.body.should.have.properties(['error', 'data']);
 
-                    es.body.error.should.equal(0);
+                    res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     res.body.data.should.equal(ossec_conf_content_master)
 
@@ -840,7 +840,7 @@ describe('Cluster', function () {
 
                     res.body.should.have.properties(['error', 'data']);
 
-                    es.body.error.should.equal(0);
+                    res.body.error.should.equal(0);
                     res.body.data.should.be.an.string;
                     res.body.data.should.equal(ossec_conf_content_worker)
 

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -855,7 +855,7 @@ describe('Cluster', function () {
     });  // POST/cluster/:node_id/files
 
 
-    describe('/cluster/:node_id/files', function() {
+    describe('GET/cluster/:node_id/files', function() {
 
         after(function (done) {
             var config = require('../configuration/config')
@@ -1049,7 +1049,8 @@ describe('Cluster', function () {
 
     });  // GET/cluster/:node_id/files
 
-    describe('/cluster/:node_id/configuration/validation (OK)', function() {
+
+    describe('GET/cluster/:node_id/configuration/validation (all nodes OK)', function() {
 
         it('Request validation (master)', function (done) {
             request(common.url)
@@ -1084,13 +1085,139 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.have.properties(['status']);
                     res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+        it('Request validation (all nodes)', function (done) {
+            request(common.url)
+                .get("/cluster/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+
                     done();
                 });
         });
 
     });  // GET/cluster/:node_id/configuration/validation (OK)
 
-    describe('/cluster/:node_id/configuration/validation (KO)', function() {
+
+    describe('GET/cluster/:node_id/configuration/validation (manager KO, worker OK)', function() {
+
+        // upload corrupted ossec.conf in master (semantic)
+        before(function (done) {
+            request(common.url)
+            .post("/cluster/master/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send("<!--  Wazuh - Manager -->\n  <ossec_config>\n    <global>\n      <jsonout_output>WRONG_VALUE</jsonout_output>\n      <alerts_log>yes</alerts_log>\n      <logall>no</logall>\n      <logall_json>no</logall_json>\n      <email_notification>no</email_notification>\n      <smtp_server>smtp.example.wazuh.com</smtp_server>\n      <email_from>ossecm@example.wazuh.com</email_from>\n      <email_to>recipient@example.wazuh.com</email_to>\n      <email_maxperhour>12</email_maxperhour>\n      <email_log_source>alerts.log</email_log_source>\n      <queue_size>131072</queue_size>\n    </global>\n <cluster>\n      <name>wazuh</name>\n      <node_name>master</node_name>\n      <node_type>master</node_type>\n      <key>XXXX</key>\n      <port>1516</port>\n      <bind_addr>192.168.122.111</bind_addr>\n      <nodes>\n        <node>192.168.122.111</node>\n      </nodes>\n      <hidden>no</hidden>\n      <disabled>no</disabled>\n    </cluster>\n  </ossec_config>\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        // restore ossec.conf (master)
+        after(function(done) {
+            request(common.url)
+            .post("/cluster/master/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send(ossec_conf_content_master)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+              });
+        });
+
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
+        it('Request validation (worker)', function (done) {
+            request(common.url)
+                .get("/cluster/worker/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+        it('Request validation (all nodes)', function (done) {
+            request(common.url)
+                .get("/cluster/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
+    });  // GET/cluster/:node_id/configuration/validation (manager KO, worker KO)
+
+
+    describe('GET/cluster/:node_id/configuration/validation (manager OK, worker KO)', function() {
 
         // upload corrupted ossec.conf in worker (semantic)
         before(function (done) {
@@ -1133,6 +1260,173 @@ describe('Cluster', function () {
               });
         });
 
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+        it('Request validation (worker)', function (done) {
+            request(common.url)
+                .get("/cluster/worker/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
+
+        it('Request validation (all nodes)', function (done) {
+            request(common.url)
+                .get("/cluster/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
+    });  // GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
+
+
+    describe('GET/cluster/:node_id/configuration/validation (manager and worker KO)', function() {
+
+        // upload corrupted ossec.conf in master (semantic)
+        before(function (done) {
+            request(common.url)
+            .post("/cluster/master/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send("<!--  Wazuh - Manager -->\n  <ossec_config>\n    <global>\n      <jsonout_output>WRONG_VALUE</jsonout_output>\n      <alerts_log>yes</alerts_log>\n      <logall>no</logall>\n      <logall_json>no</logall_json>\n      <email_notification>no</email_notification>\n      <smtp_server>smtp.example.wazuh.com</smtp_server>\n      <email_from>ossecm@example.wazuh.com</email_from>\n      <email_to>recipient@example.wazuh.com</email_to>\n      <email_maxperhour>12</email_maxperhour>\n      <email_log_source>alerts.log</email_log_source>\n      <queue_size>131072</queue_size>\n    </global>\n <cluster>\n      <name>wazuh</name>\n      <node_name>master</node_name>\n      <node_type>master</node_type>\n      <key>XXXXX</key>\n      <port>1516</port>\n      <bind_addr>192.168.122.111</bind_addr>\n      <nodes>\n        <node>192.168.122.111</node>\n      </nodes>\n      <hidden>no</hidden>\n      <disabled>no</disabled>\n    </cluster>\n  </ossec_config>\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        // upload corrupted ossec.conf in worker (semantic)
+        before(function (done) {
+            request(common.url)
+            .post("/cluster/worker/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send("<!--  Wazuh - Manager -->\n  <ossec_config>\n    <global>\n      <jsonout_output>WRONG_VALUE</jsonout_output>\n      <alerts_log>yes</alerts_log>\n      <logall>no</logall>\n      <logall_json>no</logall_json>\n      <email_notification>no</email_notification>\n      <smtp_server>smtp.example.wazuh.com</smtp_server>\n      <email_from>ossecm@example.wazuh.com</email_from>\n      <email_to>recipient@example.wazuh.com</email_to>\n      <email_maxperhour>12</email_maxperhour>\n      <email_log_source>alerts.log</email_log_source>\n      <queue_size>131072</queue_size>\n    </global>\n  </ossec_config>\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        // restore ossec.conf (master)
+        after(function(done) {
+            request(common.url)
+            .post("/cluster/master/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send(ossec_conf_content_master)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+              });
+        });
+
+        // restore ossec.conf (worker)
+        after(function(done) {
+            request(common.url)
+            .post("/cluster/worker/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send(ossec_conf_content_worker)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+              });
+        });
+
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/worker/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
         it('Request validation (worker)', function (done) {
             request(common.url)
                 .get("/cluster/worker/configuration/validation")
@@ -1173,7 +1467,8 @@ describe('Cluster', function () {
                 });
         });
 
-    });  // GET/cluster/:node_id/configuration/validation
+    });  // GET/cluster/:node_id/configuration/validation (manager and worker KO)
+
 
     describe('PUT/cluster/:node_id/restart', function() {
 

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -550,22 +550,6 @@ describe('Cluster', function () {
 
     describe('POST/cluster/:node_id/files', function() {
 
-
-        before(function (done) {
-
-            var config = require('../configuration/config')
-            var path = require('path')
-            var fs = require('fs')
-
-            // delete test files
-            fs.unlinkSync(path.join(config.ossec_path, path_rules));
-            fs.unlinkSync(path.join(config.ossec_path, path_decoders));
-            fs.unlinkSync(path.join(config.ossec_path, path_lists));
-
-            done();
-
-        });
-
         it('Upload rules', function(done) {
             request(common.url)
             .post("/cluster/master/files?path=" + path_rules)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -781,7 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.should.equal(ossec_conf_content)
+                    res.body.data.should.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1049,7 +1049,48 @@ describe('Cluster', function () {
 
     });  // GET/cluster/:node_id/files
 
-    describe('/cluster/:node_id/configuration/validation', function() {
+    describe('/cluster/:node_id/configuration/validation (OK)', function() {
+
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+        it('Request validation (worker)', function (done) {
+            request(common.url)
+                .get("/cluster/worker/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status']);
+                    res.body.data.status.should.equal('OK');
+                    done();
+                });
+        });
+
+    });  // GET/cluster/:node_id/configuration/validation (OK)
+
+    describe('/cluster/:node_id/configuration/validation (KO)', function() {
 
         // upload corrupted ossec.conf in worker (semantic)
         before(function (done) {
@@ -1092,9 +1133,9 @@ describe('Cluster', function () {
               });
         });
 
-        it('Request validation (master)', function (done) {
+        it('Request validation (worker)', function (done) {
             request(common.url)
-                .get("/cluster/master/configuration/validation")
+                .get("/cluster/worker/configuration/validation")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -1104,16 +1145,17 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.should.have.properties(['status']);
-                    res.body.data.status.should.equal('OK');
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
 
                     done();
                 });
         });
 
-        it('Request validation (worker)', function (done) {
+        it('Request validation (all nodes)', function (done) {
             request(common.url)
-                .get("/cluster/worker/configuration/validation")
+                .get("/cluster/configuration/validation")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -781,7 +781,7 @@ describe('Cluster', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.shoud.equal(ossec_conf_content)
+                    res.body.should.equal(ossec_conf_content)
                     res.body.data.should.be.an.string;
 
                     done();

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1050,7 +1050,7 @@ describe('Cluster', function () {
     });  // GET/cluster/:node_id/files
 
 
-    describe('GET/cluster/:node_id/configuration/validation (all nodes OK)', function() {
+    describe('GET/cluster/:node_id/configuration/validation (manager and worker OK)', function() {
 
         it('Request validation (master)', function (done) {
             request(common.url)
@@ -1110,7 +1110,7 @@ describe('Cluster', function () {
                 });
         });
 
-    });  // GET/cluster/:node_id/configuration/validation (OK)
+    });  // GET/cluster/:node_id/configuration/validation (manager and worker OK)
 
 
     describe('GET/cluster/:node_id/configuration/validation (manager KO, worker OK)', function() {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -452,7 +452,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.have.properties(['nodes', 'n_connected_nodes']);
 
-                    res.body.data.n_connected_nodes.should.be.above(1)
+                    res.body.data.n_connected_nodes.should.be.above(0)
 
                     res.body.data.nodes.should.have.properties([expected_name_worker, expected_name_master]);
 
@@ -511,7 +511,7 @@ describe('Cluster', function () {
                     res.body.error.should.equal(0);
                     res.body.data.should.have.properties(['nodes', 'n_connected_nodes']);
 
-                    res.body.data.n_connected_nodes.should.be.above(1)
+                    res.body.data.n_connected_nodes.should.be.above(0)
 
                     res.body.data.nodes.should.have.properties([expected_name_worker]);
 

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -622,27 +622,6 @@ describe('Manager', function() {
 
     });  // GET/manager/logs/summary
 
-    describe('PUT/manager/restart', function() {
-
-        it('Request', function(done) {
-            request(common.url)
-            .put("/manager/restart")
-            .auth(common.credentials.user, common.credentials.password)
-            .expect("Content-type",/json/)
-            .expect(200)
-            .end(function(err,res){
-                if (err) return done(err);
-
-                res.body.should.have.properties(['error', 'data']);
-
-                res.body.error.should.equal(0);
-                res.body.data.should.be.an.string;
-
-                done();
-            });
-        });
-
-    });  // PUT/manager/restart
 
     describe('POST/manager/files', function() {
 
@@ -806,7 +785,7 @@ describe('Manager', function() {
 
     });  // POST/manager/files
 
-    describe('/manager/files', function() {
+    describe('GET/manager/files', function() {
 
         after(function(done) {
             var config = require('../configuration/config')
@@ -963,5 +942,118 @@ describe('Manager', function() {
         });
 
     });  // GET/manager/files
+
+
+    describe('GET/manager/configuration/validation (OK)', function() {
+
+        it('Request validation ', function (done) {
+            request(common.url)
+                .get("/manager/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.status.should.equal('OK');
+
+                    done();
+                });
+        });
+
+    });  // GET/manager/configuration/validation (OK)
+
+
+    describe('GET/manager/configuration/validation (KO)', function() {
+
+        // upload corrupted ossec.conf in master (semantic)
+        before(function (done) {
+            request(common.url)
+            .post("/manager/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send("<!--  Wazuh - Manager -->\n  <ossec_config>\n    <global>\n      <jsonout_output>WRONG_VALUE</jsonout_output>\n      <alerts_log>yes</alerts_log>\n      <logall>no</logall>\n      <logall_json>no</logall_json>\n      <email_notification>no</email_notification>\n      <smtp_server>smtp.example.wazuh.com</smtp_server>\n      <email_from>ossecm@example.wazuh.com</email_from>\n      <email_to>recipient@example.wazuh.com</email_to>\n      <email_maxperhour>12</email_maxperhour>\n      <email_log_source>alerts.log</email_log_source>\n      <queue_size>131072</queue_size>\n    </global>\n <cluster>\n      <name>wazuh</name>\n      <node_name>master</node_name>\n      <node_type>master</node_type>\n      <key>XXXX</key>\n      <port>1516</port>\n      <bind_addr>192.168.122.111</bind_addr>\n      <nodes>\n        <node>192.168.122.111</node>\n      </nodes>\n      <hidden>no</hidden>\n      <disabled>no</disabled>\n    </cluster>\n  </ossec_config>\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        // restore ossec.conf (master)
+        after(function(done) {
+            request(common.url)
+            .post("/manager/files?path=" + path_ossec_conf)
+            .set("Content-Type", "application/xml")
+            .send(ossec_conf_content)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) throw err;
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+              });
+        });
+
+        it('Request validation (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/configuration/validation")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['status', 'details']);
+                    res.body.data.status.should.equal('KO');
+                    res.body.data.details.should.be.instanceof(Array);
+
+                    done();
+                });
+        });
+
+    });  // GET/manager/configuration/validation (KO)
+
+
+    describe('PUT/manager/restart', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .put("/manager/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+    });  // PUT/manager/restart
+
 
 });  // Manager


### PR DESCRIPTION
Hi team,

I added new mocha tests for manager:

```bash
# mocha test/test_manager.js --timeout=3000 


  Manager
    GET/manager/status
      ✓ Request (480ms)
    GET/manager/info
      ✓ Request (243ms)
    GET/manager/configuration
      ✓ Request (227ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (451ms)
      ✓ Errors: Invalid Section (232ms)
      ✓ Filters: Section - field (246ms)
      ✓ Errors: Invalid field (239ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (248ms)
      ✓ Filters: date (256ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter (39ms)
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (207ms)
    GET/manager/stats/weekly
      ✓ Request (237ms)
    GET/manager/stats/analysisd
      ✓ Request (262ms)
    GET/manager/stats/remoted
      ✓ Request (230ms)
    GET/manager/logs
      ✓ Request (317ms)
      ✓ Pagination (274ms)
      ✓ Retrieve all elements with limit=0 (291ms)
      ✓ Sort (287ms)
      ✓ SortField (351ms)
      ✓ Search (287ms)
      ✓ Filters: type_log (296ms)
      ✓ Filters: category (257ms)
      ✓ Filters: type_log and category (288ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (664ms)
    POST/manager/files
      ✓ Upload ossec.conf (210ms)
      ✓ Upload rules (222ms)
      ✓ Upload decoder (250ms)
      ✓ Upload list (236ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
    GET/manager/files
      ✓ Request ossec.conf (227ms)
      ✓ Request rules (247ms)
      ✓ Request decoders (228ms)
      ✓ Request lists (226ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (243ms)
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (539ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (master) (209ms)
    PUT/manager/restart
      ✓ Request (219ms)


  49 passing (11s)
```
Best regards,

Demetrio.