### PR TITLE
Fix mocha tests (syscollector)

### DIFF
--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -418,7 +418,7 @@ router.get('/syscollector/netaddr', function (req, res) {
     var data_request = { 'function': '/experimental/syscollector/netaddr', 'arguments': {} };
     var filters = {
         'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
+        'search': 'search_param', 'select': 'select_param', 'iface': 'alphanumeric_param',
         'proto': 'alphanumeric_param', 'address': 'alphanumeric_param',
         'broadcast': 'alphanumeric_param', 'netmask': 'alphanumeric_param',
     };
@@ -437,6 +437,8 @@ router.get('/syscollector/netaddr', function (req, res) {
         data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
     if ('search' in req.query)
         data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
+    if ('iface' in req.query)
+        data_request['arguments']['filters']['iface'] = req.query.iface;
     if ('proto' in req.query)
         data_request['arguments']['filters']['proto'] = req.query.proto;
     if ('address' in req.query)

--- a/test/test_syscollector.js
+++ b/test/test_syscollector.js
@@ -2154,6 +2154,7 @@ describe('Syscollector', function () {
                     res.body.should.have.properties(['error', 'data']);
                     res.body.error.should.equal(0);
                     res.body.data.items.should.be.instanceof(Array).and.have.lengthOf(1);
+                    expected_iface = res.body.data.items[0].iface;
                     expected_proto = res.body.data.items[0].proto;
                     expected_address = res.body.data.items[0].address;
                     expected_broadcast = res.body.data.items[0].broadcast;


### PR DESCRIPTION
Hi team,

I found a bug when I was passing mocha tests. A `iface` filter was not been considered in `/experimental/syscollector/netaddr` API call. This PR closes #325.
Best regards,

Demetrio.