### PR TITLE
Add version filter to GET/experimental/syscollector/packages API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added API calls to restart manager nodes in the cluster and validate configuration ([#307](https://github.com/wazuh/wazuh-api/pull/307))
 - Added API calls to get CDB lists ([#301](https://github.com/wazuh/wazuh-api/pull/301))
 - Added API calls to get security configuration assessment policies and checks ([#321](https://github.com/wazuh/wazuh-api/pull/321))
+- Added filtering by `version` field in `GET/experimental/syscollector/packages` API call ([#340](https://github.com/wazuh/wazuh-api/pull/340)).
 
 ### Fixed
 - Fixed documentation regarding DELETE /agents API call and older_than default value ([#319](https://github.com/wazuh/wazuh-api/pull/319))

--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -44,7 +44,7 @@ router.get('/syscollector/packages', function (req, res) {
         'search': 'search_param', 'select': 'select_param',
         'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
         'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param',
-        'version': 'alphanumeric_param'
+        'version': 'search_param'
     };
 
 

--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -27,6 +27,7 @@ var router = require('express').Router();
  * @apiParam {String} [architecture] Filters by architecture.
  * @apiParam {String} [format] Filters by format.
  * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [version] Filter by version name.
  *
  * @apiDescription Returns the agent's packages info
  *
@@ -42,7 +43,8 @@ router.get('/syscollector/packages', function (req, res) {
         'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
         'search': 'search_param', 'select': 'select_param',
         'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
-        'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param'
+        'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param',
+        'version': 'alphanumeric_param'
     };
 
 
@@ -73,6 +75,8 @@ router.get('/syscollector/packages', function (req, res) {
         data_request['arguments']['filters']['architecture'] = req.query.architecture
     if ('format' in req.query)
         data_request['arguments']['filters']['format'] = req.query.format
+    if ('version' in req.query)
+        data_request['arguments']['filters']['version'] = req.query.version;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })


### PR DESCRIPTION
Hello team,

This PR closes #339.

This is an example of how the filter works:
```javascript
# curl -u foo:bar "localhost:55000/experimental/syscollector/packages?pretty&version=0.17-1ubuntu1"
{
   "error": 0,
   "data": {
      "items": [
         {
            "scan": {
               "id": 1066845738,
               "time": "2019/03/04 16:39:27"
            },
            "multiarch": "foreign",
            "vendor": "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>",
            "description": "tool to manage well known user directories",
            "size": 533,
            "section": "utils",
            "version": "0.17-1ubuntu1",
            "architecture": "amd64",
            "priority": "optional",
            "format": "deb",
            "name": "xdg-user-dirs",
            "agent_id": "000"
         }
      ],
      "totalItems": 1
   }
}
```

Best regards,
Marta