### PR TITLE
Fix when empty path parameter is empty

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -490,7 +490,7 @@ router.get('/:node_id/logs/summary', cache(), function(req, res) {
  * @apiName GetFileCluster
  * @apiGroup Files
  *
- * @apiParam {String} path Relative path of file.
+ * @apiParam {String} path Relative path of file. This parameter is mandatory.
  *
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
@@ -531,7 +531,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
  * @apiGroup Files
  *
  * @apiParam {String} file Input file.
- * @apiParam {String} path Relative path were input file will be placed.
+ * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
  * @apiParam {String} overwrite false to fail if file already exists (default). true to replace the existing file
  *
  * @apiDescription Upload a local file (rules, decoders and lists) in a cluster node
@@ -602,7 +602,7 @@ router.post('/:node_id/files', function(req, res) {
  * @apiName DeleteClusterFiles
  * @apiGroup Files
  *
- * @apiParam {String} path Relative path of file.
+ * @apiParam {String} path Relative path of file. This parameter is mandatory.
  * 
  * @apiDescription Confirmation message.
  *

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -512,7 +512,11 @@ router.get('/:node_id/files', cache(), function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     data_request['arguments']['node_id'] = req.params.node_id;
     data_request['arguments']['path'] = req.query.path;
@@ -550,7 +554,11 @@ router.post('/:node_id/files', function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     if (req.headers['content-type'] == 'application/octet-stream') {
         // check cdb list
@@ -616,7 +624,11 @@ router.delete('/:node_id/files', cache(), function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     data_request['arguments']['path'] = req.query.path;
     data_request['arguments']['node_id'] = req.params.node_id;

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -515,7 +515,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     data_request['arguments']['node_id'] = req.params.node_id;
@@ -557,7 +557,7 @@ router.post('/:node_id/files', function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     if (req.headers['content-type'] == 'application/octet-stream') {
@@ -627,7 +627,7 @@ router.delete('/:node_id/files', cache(), function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     data_request['arguments']['path'] = req.query.path;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -305,7 +305,7 @@ router.get('/files', cache(), function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     data_request['arguments']['path'] = req.query.path;
@@ -339,7 +339,7 @@ router.delete('/files', cache(), function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     data_request['arguments']['path'] = req.query.path;
@@ -375,7 +375,7 @@ router.post('/files', function(req, res) {
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
-        res_h.bad_request(req, res, 706, err);
+        res_h.bad_request(req, res, 706);
     }
 
     if (req.headers['content-type'] == 'application/octet-stream') {

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -284,7 +284,7 @@ router.get('/stats/remoted', cache(), function(req, res) {
  * @apiName GetFile
  * @apiGroup Files
  *
- * @apiParam {String} path Relative path of file.
+ * @apiParam {String} path Relative path of file. This parameter is mandatory.
  *
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
@@ -318,7 +318,7 @@ router.get('/files', cache(), function(req, res) {
  * @apiName DeleteManagerFiles
  * @apiGroup Files
  *
- * @apiParam {String} path Relative path of file.
+ * @apiParam {String} path Relative path of file. This parameter is mandatory.
  * 
  * @apiDescription Confirmation message.
  *
@@ -353,7 +353,7 @@ router.delete('/files', cache(), function(req, res) {
  * @apiGroup Files
  *
  * @apiParam {String} file Input file.
- * @apiParam {String} path Relative path were input file will be placed.
+ * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
  * @apiParam {String} overwrite false to fail if file already exists (default). true to replace the existing file
  *
  * @apiDescription Upload a local file (rules, decoders and lists).

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -302,7 +302,11 @@ router.get('/files', cache(), function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     data_request['arguments']['path'] = req.query.path;
 
@@ -332,7 +336,11 @@ router.delete('/files', cache(), function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     data_request['arguments']['path'] = req.query.path;
 
@@ -364,7 +372,11 @@ router.post('/files', function(req, res) {
         return;
 
     // check path parameter
-    if (!filter.check_path(req.query.path, req, res)) return;
+    if (req.query.path) {
+        if (!filter.check_path(req.query.path, req, res)) return;
+    } else {
+        res_h.bad_request(req, res, 706, err);
+    }
 
     if (req.headers['content-type'] == 'application/octet-stream') {
         // check cdb list

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -65,7 +65,7 @@ errors['702'] = "Could not write XML temporary file";
 errors['703'] = 'Invalid XML file';
 errors['704'] = 'Invalid path';
 errors['705'] = 'Invalid CDB list';
-errors['706'] = '\'path\' parameter is empty';
+errors['706'] = '\'path\' parameter is mandatory';
 
 // Headers
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";

--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -65,6 +65,7 @@ errors['702'] = "Could not write XML temporary file";
 errors['703'] = 'Invalid XML file';
 errors['704'] = 'Invalid path';
 errors['705'] = 'Invalid CDB list';
+errors['706'] = '\'path\' parameter is empty';
 
 // Headers
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -968,6 +968,26 @@ describe('Cluster', function () {
               });
         });
 
+        it('Upload list with empty path', function(done) {
+            request(common.url)
+            .post("/cluster/master/files")
+            .set("Content-Type", "application/octet-stream")
+            .send("test&%-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
+
+                done();
+              });
+        });
+
     });  // POST/cluster/:node_id/files
 
 
@@ -1145,6 +1165,24 @@ describe('Cluster', function () {
                 res.body.should.have.properties(['error', 'message']);
 
                 res.body.error.should.equal(3022);
+
+                done();
+            });
+        });
+
+        it('Request file with empty path', function(done) {
+            request(common.url)
+            .get("/cluster/master/files")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
 
                 done();
             });
@@ -1622,6 +1660,24 @@ describe('Cluster', function () {
 
                 res.body.error.should.equal(0);
                 res.body.data.should.be.an.string;
+                done();
+            });
+        });
+
+        it('Delete file with empty path', function(done) {
+            request(common.url)
+            .delete("/cluster/master/files")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
+
                 done();
             });
         });

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -880,6 +880,26 @@ describe('Manager', function() {
               });
         });
 
+        it('Upload list with empty path', function(done) {
+            request(common.url)
+            .post("/manager/files")
+            .set("Content-Type", "application/octet-stream")
+            .send("test&%-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
+
+                done();
+              });
+        });
+
     });  // POST/manager/files
 
     describe('GET/manager/files', function() {
@@ -1025,6 +1045,24 @@ describe('Manager', function() {
             });
         });
 
+        it('Request file with empty path', function(done) {
+            request(common.url)
+            .get("/manager/files")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
+
+                done();
+            });
+        });
+
     });  // GET/manager/files
 
     describe('DELETE/manager/files', function() {
@@ -1076,6 +1114,24 @@ describe('Manager', function() {
 
                 res.body.error.should.equal(0);
                 res.body.data.should.be.an.string;
+                done();
+            });
+        });
+
+        it('Delete file with empty path', function(done) {
+            request(common.url)
+            .delete("/manager/files")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(706);
+                res.body.message.should.be.an.string;
+
                 done();
             });
         });


### PR DESCRIPTION
Hi team,

This PR closes #342. An unhandled exception was generated when `path` parameter was empty. This PR fixes it. Below there are examples showing this fix.

#### GET

##### manager

```bash
 # curl -u foo:bar -k -X GET "http://127.0.0.1:55000/manager/files?pretty"
{
   "error": 706,
   "message": "'path' parameter is empty"
}

##### cluster

``bash
 # curl -u foo:bar -k -X GET "http://127.0.0.1:55000/cluster/master/files?pretty"
{
   "error": 706,
   "message": "'path' parameter is empty"
}
```

#### POST

##### manager

```bash
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @/root/ossec.conf-short "http://127.0.0.1:55000/manager/files?pretty"
{
   "error": 706,
   "message": "'path' parameter is empty"
}
```
##### cluster

```bash
# curl -u foo:bar -X POST -H 'Content-type: application/xml' -d @/root/ossec.conf-short "http://127.0.0.1:55000/cluster/master/files?pretty"
{
   "error": 706,
   "message": "'path' parameter is empty"
}
```

#### DELETE

##### manager

```bash
# curl -u foo:bar -X DELETE "http://127.0.0.1:55000/manager/files?pretty"                             
{
   "error": 706,
   "message": "'path' parameter is empty"
}
```
##### cluster

```bash
# curl -u foo:bar -X DELETE "http://127.0.0.1:55000/cluster/master/files?pretty"
{
   "error": 706,
   "message": "'path' parameter is empty"
}
```

#### tests

##### manager

```javascript
POST/manager/files
      ✓ Upload ossec.conf (191ms)
      ✓ Upload ossec.conf (overwrite=false) (237ms)
      ✓ Upload rules (new rule) (218ms)
      ✓ Upload rules (overwrite=true) (222ms)
      ✓ Upload rules (overwrite=false) (281ms)
      ✓ Upload decoder (overwrite=true) (220ms)
      ✓ Upload decoder (without overwrite parameter) (241ms)
      ✓ Upload list (overwrite=true) (236ms)
      ✓ Upload list (without overwrite parameter) (234ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path ----> NEW
    GET/manager/files
      ✓ Request ossec.conf (203ms)
      ✓ Request rules (216ms)
      ✓ Request decoders (249ms)
      ✓ Request lists (268ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (253ms)
      ✓ Request file with empty path ----> NEW
    DELETE/manager/files
      ✓ Delete rules (405ms)
      ✓ Delete decoders (238ms)
      ✓ Delete CDB list (274ms)
      ✓ Delete file with empty path ----> NEW
```

##### cluster

```javascript
POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (204ms)
      ✓ Upload ossec.conf (worker) (301ms)
      ✓ Upload new rules (256ms)
      ✓ Upload rules (overwrite=true) (223ms)
      ✓ Upload rules (overwrite=false) (237ms)
      ✓ Upload new decoder (225ms)
      ✓ Upload decoder (overwrite=true) (239ms)
      ✓ Upload decoder (without overwrite parameter) (275ms)
      ✓ Upload new list (241ms)
      ✓ Upload list (overwrite=true) (257ms)
      ✓ Upload list (overwrite=false) (241ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (244ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (241ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (224ms)
      ✓ Upload list with empty path ----> NEW
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (202ms)
      ✓ Request ossec.conf (worker) (237ms)
      ✓ Request rules (236ms)
      ✓ Request decoders (217ms)
      ✓ Request lists (225ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (237ms)
      ✓ Request file from unexisting node (285ms)
      ✓ Request file with empty path ----> NEW
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (225ms)
      ✓ Delete decoders (master) (233ms)
      ✓ Delete CDB list (master) (411ms)
      ✓ Delete file with empty path ----> NEW
```

Best regards,

Demetrio.