### PR TITLE
Disable API cache when generating documentation

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -495,7 +495,7 @@ router.get('/:node_id/logs/summary', cache(), function(req, res) {
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/files?path=etc/rules/local_rules.xml&pretty"
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node01/files?path=etc/decoders/local_decoder.xml&pretty"
  *
  */
 router.get('/:node_id/files', cache(), function(req, res) {
@@ -533,7 +533,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
  * @apiDescription Upload a local file (rules, decoders and lists) in a cluster node
  *
  * @apiExample {curl} Example usage*:
- *     curl -u foo:bar -k -X POST -H 'Content-type: application/xml' -d @rules.xml "https://127.0.0.1:55000/cluster/node02/files?path=etc/rules/local_rules.xml&pretty"
+ *     curl -u foo:bar -k -X POST -H 'Content-type: application/xml' -d @rules.xml "https://127.0.0.1:55000/cluster/node01/files?path=etc/rules/local_rules.xml&pretty"
  *
  */
 router.post('/:node_id/files', function(req, res) {
@@ -599,7 +599,7 @@ router.post('/:node_id/files', function(req, res) {
  * @apiDescription Confirmation message.
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/cluster/node02/files?path=etc/rules/local_rules.xml&pretty"
+ *     curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/cluster/node01/files?path=etc/rules/local_rules.xml&pretty"
  *
  */
 router.delete('/:node_id/files', cache(), function(req, res) {

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -289,7 +289,7 @@ router.get('/stats/remoted', cache(), function(req, res) {
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/files?path=etc/rules/local_rules.xml&pretty"
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/files?path=etc/decoders/local_decoder.xml&pretty"
  *
  */
 router.get('/files', cache(), function(req, res) {

--- a/doc/build_environment/configure_manager.sh
+++ b/doc/build_environment/configure_manager.sh
@@ -45,6 +45,7 @@ EOT
 
 sed -i "s:wazuh_database.sync_syscheck=0:wazuh_database.sync_syscheck=1:g" /var/ossec/etc/internal_options.conf
 sed -i "s:config.experimental_features  = false;:config.experimental_features = true;:g" /var/ossec/api/configuration/config.js
+sed -i "s:config.cache_enabled = \"yes\";:config.cache_enabled = \"no\";:g" /var/ossec/api/configuration/config.js
 
 npm install apidoc -g
 apt-get install python-pip -y


### PR DESCRIPTION
Hello team,

This PR fixes the API documentation generation process. Since the cache was enabled, the API calls `DELETE/manager/files` and `GET/manager/files` were returning the same values in the documentation (https://github.com/wazuh/wazuh-documentation/pull/996).

Best regards,
Marta