### PR TITLE
Fix download parameter (rules and decoders calls)

### DIFF
--- a/helpers/response_handler.js
+++ b/helpers/response_handler.js
@@ -116,14 +116,14 @@ exports.send_file = function(req, res, file_name, type){
                     send_aux(req, res, json_res, 404);
                     return;
                 }
-                var stat = fileSystem.statSync(filepath);
+                var stat = fileSystem.statSync(conf.ossec_path + '/' + filepath);
 
                 res.writeHead(200, {
                 'Content-Type': 'text/xml',
                 'Content-Length': stat.size
                 });
 
-                var readStream = fileSystem.createReadStream(filepath);
+                var readStream = fileSystem.createReadStream(conf.ossec_path + '/' + filepath);
 
                 readStream.pipe(res)
 

--- a/test/test_decoders.js
+++ b/test/test_decoders.js
@@ -130,7 +130,7 @@ describe('Decoders', function() {
 
         it('Filters: Path', function(done) {
             request(common.url)
-            .get("/decoders?path=/var/ossec/etc/decoders")
+            .get("/decoders?path=etc/decoders")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -222,7 +222,7 @@ describe('Rules', function() {
 
         it('Filters: path', function(done) {
             request(common.url)
-            .get("/rules?path=/var/ossec/ruleset/rules")
+            .get("/rules?path=ruleset/rules")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)


### PR DESCRIPTION
Hi team,

This PR closes #347. We got an error when we tried to get the content of a rule or decoder and this has been fixed.

Furthermore, mocha tests were updated because parameter `path` was not working properly.

#### Tests performed

##### Rules

```javascript
# mocha test/test_rules.js --timeout=10000


  Rules
    GET/rules
      ✓ Request (714ms)
      ✓ Pagination (302ms)
      ✓ Retrieve all elements with limit=0 (313ms)
      ✓ Sort (320ms)
      ✓ Search (475ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (316ms)
      ✓ Filters: group (335ms)
      ✓ Filters: level (1) (304ms)
      ✓ Filters: level (2) (390ms)
      ✓ Filters: path (306ms)
      ✓ Filters: file (381ms)
      ✓ Filters: pci (366ms)
      ✓ Filters: gdpr (302ms)
    GET/rules/groups
      ✓ Request (355ms)
      ✓ Pagination (293ms)
      ✓ Retrieve all elements with limit=0 (310ms)
      ✓ Sort (293ms)
      ✓ Search (329ms)
      ✓ Filters: Invalid filter
    GET/rules/pci
      ✓ Request (299ms)
      ✓ Pagination (307ms)
      ✓ Retrieve all elements with limit=0 (292ms)
      ✓ Sort (311ms)
      ✓ Search (300ms)
      ✓ Filters: Invalid filter
    GET/rules/gdpr
      ✓ Request (365ms)
      ✓ Pagination (383ms)
      ✓ Retrieve all elements with limit=0 (275ms)
      ✓ Sort (307ms)
      ✓ Search (281ms)
      ✓ Filters: Invalid filter
    GET/rules/files
      ✓ Request (202ms)
      ✓ Pagination (234ms)
      ✓ Retrieve all elements with limit=0 (209ms)
      ✓ Sort (292ms)
      ✓ Search (222ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (219ms)
      ✓ Filters: download (256ms)
    GET/rules/:rule_id
      ✓ Request (289ms)
      ✓ Pagination (325ms)
      ✓ Retrieve all elements with limit=0 (297ms)
      ✓ Sort (304ms)
      ✓ Search (382ms)
      ✓ Filters: Invalid filter
      ✓ Params: Bad rule id
      ✓ Params: No rule (355ms)


  50 passing (13s)

```
##### Decoders

```javascript
# mocha test/test_decoders.js --timeout=10000


  Decoders
    GET/decoders
      ✓ Request (295ms)
      ✓ Pagination (265ms)
      ✓ Retrieve all elements with limit=0 (241ms)
      ✓ Sort (269ms)
      ✓ Search (248ms)
      ✓ Filters: File (244ms)
      ✓ Filters: Path (299ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/decoders/files
      ✓ Request (220ms)
      ✓ Pagination (244ms)
      ✓ Retrieve all elements with limit=0 (223ms)
      ✓ Sort (227ms)
      ✓ Search (234ms)
    GET/decoders/parents
      ✓ Request (241ms)
      ✓ Pagination (253ms)
      ✓ Retrieve all elements with limit=0 (240ms)
      ✓ Sort (240ms)
      ✓ Search (257ms)
    GET/decoders/:decoder_name
      ✓ Request (273ms)
      ✓ Pagination (499ms)
      ✓ Retrieve all elements with limit=0 (829ms)
      ✓ Sort (400ms)
      ✓ Search (260ms)


  24 passing (7s)

```

Best regards,

Demetrio.