### PR TITLE
Improve input validation of API queries

### DIFF
--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -58,6 +58,8 @@ errors['yes_no_boolean'] = 620;
 errors['620'] = "Param not valid. Valid values: yes or no";
 errors['array_names'] = 621;
 errors['621'] = "Invalid character in parameters";
+errors['query_param'] = 622;
+errors['622'] = 'Param not valid. Review queries documentation: https://documentation.wazuh.com/current/user-manual/api/queries.html'
 
 errors['700'] = "File not found";
 errors['701'] = "Size of XML file is too long";

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -89,7 +89,7 @@ exports.boolean = function(b) {
 }
 
 exports.query_param = function(q) {
-    return input_val(q, /[\w \d]+/);
+    return input_val(q, /^(?:[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)(?:(?:;|,)[\w\.\-]+(?:=|!=|<|>|~)[\w\.\- ]+)*$/);
 }
 
 exports.format = function(q) {


### PR DESCRIPTION
Hello team,

When an API query wasn't correct, the following error was shown by the API:
```json
{
   "error": "Undefined error.",
   "message": "Undefined error..  Field: q"
}
```
Now the following error message is returned:
```json
{
   "error": 622,
   "message": "Param not valid. Review queries documentation: https://documentation.wazuh.com/current/user-manual/api/queries.html.
 Field: q"
}
```
Also, some invalid parameters were accepted by the input validation regex:
```json
# curl -u foo:bar "localhost:55000/agents?pretty&q=name~mas;ter"
{
   "error": 2003,
   "message": "Error in database request"
}
```

Best regards,
Marta