### PR TITLE
Fix for uploading CDB lists

### DIFF
--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -64,10 +64,10 @@ errors['622'] = 'Param not valid. Review queries documentation: https://document
 errors['700'] = "File not found";
 errors['701'] = "Size of XML file is too long";
 errors['702'] = "Could not write XML temporary file";
-errors['703'] = 'Invalid XML file';
-errors['704'] = 'Invalid path';
-errors['705'] = 'Invalid CDB list';
-errors['706'] = '\'path\' parameter is mandatory';
+errors['703'] = "Invalid XML file";
+errors['704'] = "Invalid path";
+errors['705'] = "Invalid CDB list. Format for CDB list is 'key:value'";
+errors['706'] = "'path' parameter is mandatory";
 
 // Headers
 errors['800'] = "Error adding agent due to header 'x-forwarded-for' is not present";

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -78,7 +78,7 @@ exports.check_path = function(path, req, res) {
 
 exports.check_cdb_list = function(cdb_list, req, res) {
     // for each line
-    re = new RegExp(/^#?[\d\w\s-]+:{1}(#?[\d\w\s-]+|)/)
+    re = new RegExp(/^([^:]*\s*)+:([^:]*)$/)
     var cdb_list_splitted = cdb_list.split('\n')
     for (i=0; i<cdb_list_splitted.length-1; i++) {
         if (!re.test(cdb_list_splitted[i])) {

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -78,8 +78,8 @@ exports.check_path = function(path, req, res) {
 
 exports.check_cdb_list = function(cdb_list, req, res) {
     // for each line
-    re = new RegExp(/^(?!\s*:)([^:]*):([^:]*)$/)
-    var cdb_list_splitted = cdb_list.split(/\r\n|\n/)
+    re = new RegExp(/^[^:]+:[^:]*$/)
+    var cdb_list_splitted = cdb_list.split(/\r?\n/)
 
     for (i=0; i<cdb_list_splitted.length-1; i++) {
 

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -79,7 +79,7 @@ exports.check_path = function(path, req, res) {
 exports.check_cdb_list = function(cdb_list, req, res) {
     // for each line
     re = new RegExp(/^(?!\s*:)([^:]*):([^:]*)$/)
-    var cdb_list_splitted = cdb_list.split('\n')
+    var cdb_list_splitted = cdb_list.split(/\r\n|\n/)
 
     for (i=0; i<cdb_list_splitted.length-1; i++) {
 

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -78,9 +78,15 @@ exports.check_path = function(path, req, res) {
 
 exports.check_cdb_list = function(cdb_list, req, res) {
     // for each line
-    re = new RegExp(/^([^:]*\s*)+:([^:]*)$/)
+    re = new RegExp(/^(?!\s*:)([^:]*):([^:]*)$/)
     var cdb_list_splitted = cdb_list.split('\n')
+
     for (i=0; i<cdb_list_splitted.length-1; i++) {
+
+        if (cdb_list_splitted[i] == '') {
+            continue;
+        }
+
         if (!re.test(cdb_list_splitted[i])) {
             var line_error = 'Line ' + (i+1) + ': ' + cdb_list_splitted[i]
             res_h.bad_request(req, res, 705, line_error);

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -864,7 +864,7 @@ describe('Manager', function() {
             request(common.url)
             .post("/manager/files?path=" + path_lists + "&overwrite=true")
             .set("Content-Type", "application/octet-stream")
-            .send("test&%-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
+            .send(":write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(400)


### PR DESCRIPTION
Hi team,

This PR closes issue [#2879](https://github.com/wazuh/wazuh/issues/2879).  I updated the regular expression for validating `CDB lists` and I made changes to accept empty lines:

```bash
# cat /root/list.txt               
audit-wazuh-w:write
audit-wazuh-r:read
audit-wazuh-a:attribute

audit-wazuh-x:execute
     key:value

audit-wazuh-c:command
1.1.1.1:list
2.3.4.4:#
# curl -u foo:bar -X POST -H 'Content-type: application/octet-stream' --data-binary @/root/list.txt "http://127.0.0.1:55000/manager/files?path=etc/lists/new-list&overwrite=true"
{"error":0,"data":"File updated successfully"}
# cat /var/ossec/etc/lists/new-list
audit-wazuh-w:write
audit-wazuh-r:read
audit-wazuh-a:attribute
audit-wazuh-x:execute
key:value
audit-wazuh-c:command
1.1.1.1:list
2.3.4.4:#
```
#### Tests performed

```javascript
# mocha test/test_manager.js


  Manager
    GET/manager/status
      ✓ Request (463ms)
    GET/manager/info
      ✓ Request (203ms)
    GET/manager/configuration
      ✓ Request (223ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (384ms)
      ✓ Errors: Invalid Section (224ms)
      ✓ Filters: Section - field (191ms)
      ✓ Errors: Invalid field (190ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (201ms)
      ✓ Filters: date (200ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (190ms)
    GET/manager/stats/weekly
      ✓ Request (217ms)
    GET/manager/stats/analysisd
      ✓ Request (207ms)
    GET/manager/stats/remoted
      ✓ Request (192ms)
    GET/manager/logs
      ✓ Request (249ms)
      ✓ Pagination (236ms)
      ✓ Retrieve all elements with limit=0 (234ms)
      ✓ Sort (230ms)
      ✓ SortField (229ms)
      ✓ Search (277ms)
      ✓ Filters: type_log (232ms)
      ✓ Filters: category (223ms)
      ✓ Filters: type_log and category (227ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (219ms)
    POST/manager/files
      ✓ Upload ossec.conf (198ms)
      ✓ Upload ossec.conf (overwrite=false) (193ms)
      ✓ Upload rules (new rule) (201ms)
      ✓ Upload rules (overwrite=true) (192ms)
      ✓ Upload rules (overwrite=false) (191ms)
      ✓ Upload decoder (overwrite=true) (203ms)
      ✓ Upload decoder (without overwrite parameter) (189ms)
      ✓ Upload list (overwrite=true) (192ms)
      ✓ Upload list (without overwrite parameter) (226ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
    GET/manager/files
      ✓ Request ossec.conf (384ms)
      ✓ Request rules (215ms)
      ✓ Request decoders (193ms)
      ✓ Request lists (190ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (202ms)
      ✓ Request file with empty path
    DELETE/manager/files
      ✓ Delete rules
      ✓ Delete decoders
      ✓ Delete CDB list
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (873ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (209ms)
    PUT/manager/restart
      ✓ Request (189ms)


  60 passing (11s)

```
Best regards,

Demetrio.