### PR TITLE
Add mocha test for POST/agents/restart API call

### DIFF
--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -2121,6 +2121,69 @@ describe('Agents', function() {
 
     });  // PUT/agents/:agent_id/restart
 
+    describe('POST/agents/restart', function() {
+
+        it('Request', function(done) {
+            this.timeout(common.timeout);
+
+            request(common.url)
+            .post("/agents/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .send({ 'ids': ['001']})
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.type('object');
+                res.body.data.should.have.properties(['msg', 'affected_agents']);
+                res.body.data.affected_agents[0].should.equal('001');
+                res.body.data.msg.should.equal('All selected agents were restarted');
+                done();
+            });
+        });
+
+        it('Params: Bad agent id', function(done) {
+            request(common.url)
+            .post("/agents/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .send({ 'ids': ['abc']})
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(616);
+                done();
+            });
+        });
+
+        it('Request', function(done) {
+            this.timeout(common.timeout);
+
+            request(common.url)
+            .post("/agents/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .send({ 'ids': ['000']})
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['msg', 'failed_ids', 'affected_agents']);
+
+                res.body.data.failed_ids[0].error.code.should.equal(1703);
+                done();
+            });
+        });
+
+    });  // POST/agents/restart
+
     agent1_id = "";
     agent2_id = "";
     describe('DELETE/agents', function () {

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -2146,6 +2146,31 @@ describe('Agents', function() {
             });
         });
 
+        it('Params: A good id and a bad one', function(done) {
+            this.timeout(common.timeout);
+
+            request(common.url)
+            .post("/agents/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .send({ 'ids': ['001', '005']})
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.type('object');
+                res.body.data.should.have.properties(['msg', 'affected_agents', 'failed_ids']);
+                res.body.data.affected_agents[0].should.equal('001');
+                res.body.data.failed_ids[0].id.should.equal('005');
+                res.body.data.failed_ids[0].error.code.should.equal(1701);
+                res.body.data.msg.should.equal('Some agents were not restarted');
+                done();
+            });
+        });
+
         it('Params: Bad agent id', function(done) {
             request(common.url)
             .post("/agents/restart")


### PR DESCRIPTION
Hello team,

This PR adds mocha tests for https://github.com/wazuh/wazuh/pull/2943.

Without the fix:
```javascript
# mocha test/test_agents.js --grep POST/agents/restart


  Agents
    POST/agents/restart
      1) Request
      ✓ Params: Bad agent id
      2) Request


  1 passing (978ms)
  2 failing

  1) Agents
       POST/agents/restart
         Request:
     Uncaught AssertionError: expected Object { error: 1403, message: 'Sort field invalid' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:356:19)
      at Test.<anonymous> (test/test_agents.js:2138:38)
      at Test.assert (node_modules/supertest/lib/test.js:181:6)
      at localAssert (node_modules/supertest/lib/test.js:131:12)
      at /home/vagrant/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
      at parser (node_modules/superagent/lib/node/index.js:916:18)
      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)

  2) Agents
       POST/agents/restart
         Request:
     Uncaught AssertionError: expected Object { error: 1403, message: 'Sort field invalid' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:275:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:356:19)
      at Test.<anonymous> (test/test_agents.js:2177:38)
      at Test.assert (node_modules/supertest/lib/test.js:181:6)
      at localAssert (node_modules/supertest/lib/test.js:131:12)
      at /home/vagrant/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
      at parser (node_modules/superagent/lib/node/index.js:916:18)
      at IncomingMessage.res.on (node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

With the fix:
```javascript
# mocha test/test_agents.js --grep POST/agents/restart


  Agents
    POST/agents/restart
      ✓ Request (421ms)
      ✓ Params: Bad agent id
      ✓ Request (374ms)


  3 passing (853ms)
```

Best regards,
Marta