### PR TITLE
Add support for API queries in CIS-CAT and Syscollector

### DIFF
--- a/controllers/ciscat.js
+++ b/controllers/ciscat.js
@@ -32,6 +32,7 @@ var router = require('express').Router();
  * @apiParam {Number} [notchecked] Filters by not checked.
  * @apiParam {Number} [unknown] Filters by unknown results.
  * @apiParam {Number} [score] Filters by final score.
+ * @apiParam {String} [q] Advanced query filtering.
  *
  * @apiDescription Returns the agent's ciscat results info
  *
@@ -41,56 +42,12 @@ var router = require('express').Router();
  */
 router.get('/:agent_id/results', function (req, res) {
     logger.debug(req.connection.remoteAddress + " GET /ciscat/:agent_id/results");
-
-    var data_request = { 'function': '/ciscat/:agent_id/results', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-
-        'benchmark': 'alphanumeric_param', 'profile': 'alphanumeric_param', 'pass': 'alphanumeric_param',
-        'fail': 'alphanumeric_param',
-        'error': 'numbers', 'notchecked': 'numbers',
-        'unknown': 'numbers', 'score': 'numbers'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('benchmark' in req.query)
-        data_request['arguments']['filters']['benchmark'] = req.query.benchmark;
-    if ('profile' in req.query)
-        data_request['arguments']['filters']['profile'] = req.query.profile;
-    if ('pass' in req.query)
-        data_request['arguments']['filters']['pass'] = req.query.pass;
-    if ('fail' in req.query)
-        data_request['arguments']['filters']['fail'] = req.query.fail;
-    if ('error' in req.query)
-        data_request['arguments']['filters']['error'] = req.query.error;
-    if ('notchecked' in req.query)
-        data_request['arguments']['filters']['notchecked'] = req.query.notchecked;
-    if ('unknown' in req.query)
-        data_request['arguments']['filters']['unknown'] = req.query.unknown;
-    if ('score' in req.query)
-        data_request['arguments']['filters']['score'] = req.query.score;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
-})
+    var filters = {'benchmark': 'alphanumeric_param', 'profile': 'alphanumeric_param', 
+                   'pass': 'alphanumeric_param', 'fail': 'alphanumeric_param',
+                   'error': 'numbers', 'notchecked': 'numbers',
+                   'unknown': 'numbers', 'score': 'numbers'
+                  };
+    templates.array_request("/ciscat/:agent_id/results", req, res, "ciscat", {'agent_id': 'numbers'}, filters);
+});
 
 module.exports = router;

--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -144,7 +144,6 @@ router.get('/syscollector/processes', function (req, res) {
     templates.array_request("/experimental/syscollector/processes", req, res, "syscollector", {}, filters);
 })
 
-
 /**
  * @api {get} /experimental/syscollector/ports Get ports info of all agents
  * @apiName GetPorts
@@ -179,7 +178,6 @@ router.get('/syscollector/ports', function (req, res) {
     templates.array_request("/experimental/syscollector/ports", req, res, "syscollector", {}, filters);
 })
 
-
 /**
  * @api {get} /experimental/syscollector/netaddr Get network address info of all agents
  * @apiName GetNetaddr
@@ -208,7 +206,6 @@ router.get('/syscollector/netaddr', function (req, res) {
     templates.array_request("/experimental/syscollector/netaddr", req, res, "syscollector", {}, filters);
 })
 
-
 /**
  * @api {get} /experimental/syscollector/netproto Get network protocol info of all agents
  * @apiName GetNetproto
@@ -236,7 +233,6 @@ router.get('/syscollector/netproto', function (req, res) {
                 };
     templates.array_request("/experimental/syscollector/netproto", req, res, "syscollector", {}, filters);
 })
-
 
 /**
  * @api {get} /experimental/syscollector/netiface Get network interface info of all agents
@@ -281,7 +277,6 @@ router.get('/syscollector/netiface', function (req, res) {
     templates.array_request("/experimental/syscollector/netiface", req, res, "syscollector", {}, filters);
 })
 
-
 /**
  * @api {get} /experimental/ciscat/results Get CIS-CAT results
  * @apiName GetCiscat
@@ -309,56 +304,12 @@ router.get('/syscollector/netiface', function (req, res) {
  *
  */
 router.get('/ciscat/results', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/ciscat/results");
-
-    var data_request = { 'function': '/experimental/ciscat/results', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'benchmark': 'alphanumeric_param', 'profile': 'alphanumeric_param', 'pass': 'alphanumeric_param',
-        'fail': 'alphanumeric_param',
-        'error': 'numbers', 'notchecked': 'numbers',
-        'unknown': 'numbers', 'score': 'numbers'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('benchmark' in req.query)
-        data_request['arguments']['filters']['benchmark'] = req.query.benchmark;
-    if ('profile' in req.query)
-        data_request['arguments']['filters']['profile'] = req.query.profile;
-    if ('pass' in req.query)
-        data_request['arguments']['filters']['pass'] = req.query.pass;
-    if ('fail' in req.query)
-        data_request['arguments']['filters']['fail'] = req.query.fail;
-    if ('error' in req.query)
-        data_request['arguments']['filters']['error'] = req.query.error;
-    if ('notchecked' in req.query)
-        data_request['arguments']['filters']['notchecked'] = req.query.notchecked;
-    if ('unknown' in req.query)
-        data_request['arguments']['filters']['unknown'] = req.query.unknown;
-    if ('score' in req.query)
-        data_request['arguments']['filters']['score'] = req.query.score;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'benchmark': 'alphanumeric_param', 'profile': 'alphanumeric_param', 
+                   'pass': 'alphanumeric_param', 'fail': 'alphanumeric_param',
+                   'error': 'numbers', 'notchecked': 'numbers',
+                   'unknown': 'numbers', 'score': 'numbers'
+                };
+    templates.array_request("/experimental/ciscat/results", req, res, "ciscat", {}, filters);
 })
 
 /**

--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -17,7 +17,6 @@ var router = require('express').Router();
  * @apiName GetPackages
  * @apiGroup Packages
  *
- * @apiParam {Number} agent_id Agent ID.
  * @apiParam {Number} [offset] First element to return in the collection.
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
@@ -36,49 +35,10 @@ var router = require('express').Router();
  *
  */
 router.get('/syscollector/packages', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/packages");
-
-    var data_request = { 'function': '/experimental/syscollector/packages', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
-        'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param',
-        'version': 'search_param'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('vendor' in req.query)
-        data_request['arguments']['filters']['vendor'] = req.query.vendor
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name
-    if ('architecture' in req.query)
-        data_request['arguments']['filters']['architecture'] = req.query.architecture
-    if ('format' in req.query)
-        data_request['arguments']['filters']['format'] = req.query.format
-    if ('version' in req.query)
-        data_request['arguments']['filters']['version'] = req.query.version;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
+                   'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param', 
+                   'version' : 'alphanumeric_param'};
+    templates.array_request("/experimental/syscollector/packages", req, res, "syscollector", {}, filters);
 })
 
 /**
@@ -86,7 +46,6 @@ router.get('/syscollector/packages', function (req, res) {
  * @apiName GetOS
  * @apiGroup OS
  *
- * @apiParam {Number} agent_id Agent ID.
  * @apiParam {Number} [offset] First element to return in the collection.
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
@@ -105,50 +64,11 @@ router.get('/syscollector/packages', function (req, res) {
  *
  */
 router.get('/syscollector/os', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/os");
-
-    var data_request = { 'function': '/experimental/syscollector/os', 'arguments': {} };
-
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'os_name': 'alphanumeric_param', 'architecture': 'alphanumeric_param',
-        'os_version': 'alphanumeric_param', 'version': 'alphanumeric_param', 'release': 'alphanumeric_param'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('architecture' in req.query)
-        data_request['arguments']['filters']['architecture'] = req.query.architecture
-    if ('os_name' in req.query)
-        data_request['arguments']['filters']['os_name'] = req.query.os_name
-    if ('os_version' in req.query)
-        data_request['arguments']['filters']['os_version'] = req.query.os_version
-    if ('version' in req.query)
-        data_request['arguments']['filters']['version'] = req.query.version
-    if ('release' in req.query)
-        data_request['arguments']['filters']['release'] = req.query.release
-
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'os_name': 'alphanumeric_param', 'architecture': 'alphanumeric_param',
+                   'os_version': 'alphanumeric_param', 'version': 'alphanumeric_param', 
+                   'release': 'alphanumeric_param'
+                  };
+    templates.array_request("/experimental/syscollector/os", req, res, "syscollector", {}, filters);
 })
 
 /**
@@ -156,7 +76,6 @@ router.get('/syscollector/os', function (req, res) {
  * @apiName GetHardware
  * @apiGroup Hardware
  *
- * @apiParam {Number} agent_id Agent ID.
  * @apiParam {Number} [offset] First element to return in the collection.
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
@@ -176,53 +95,12 @@ router.get('/syscollector/os', function (req, res) {
  *
  */
 router.get('/syscollector/hardware', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/hardware");
-
-    var data_request = { 'function': '/experimental/syscollector/hardware', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'ram_free': 'numbers', 'ram_total': 'numbers', 'cpu_cores': 'numbers', 'cpu_mhz': 'alphanumeric_param',
-        'cpu_name': 'alphanumeric_param', 'board_serial': 'alphanumeric_param'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('ram_free' in req.query)
-        data_request['arguments']['filters']['ram_free'] = req.query.ram_free
-    if ('ram_total' in req.query)
-        data_request['arguments']['filters']['ram_total'] = req.query.ram_total
-    if ('cpu_cores' in req.query)
-        data_request['arguments']['filters']['cpu_cores'] = req.query.cpu_cores
-    if ('cpu_mhz' in req.query)
-        data_request['arguments']['filters']['cpu_mhz'] = req.query.cpu_mhz
-    if ('cpu_name' in req.query)
-        data_request['arguments']['filters']['cpu_name'] = req.query.cpu_name
-    if ('board_serial' in req.query)
-        data_request['arguments']['filters']['board_serial'] = req.query.board_serial
-
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'ram_free': 'numbers', 'ram_total': 'numbers', 'cpu_cores': 'numbers', 
+                   'cpu_mhz': 'alphanumeric_param', 'cpu_name': 'alphanumeric_param',
+                   'board_serial': 'alphanumeric_param'
+                };
+    templates.array_request("/experimental/syscollector/hardware", req, res, "syscollector", {}, filters);
 })
-
 
 /**
  * @api {get} /experimental/syscollector/processes Get processes info of all agents
@@ -256,67 +134,14 @@ router.get('/syscollector/hardware', function (req, res) {
  *
  */
 router.get('/syscollector/processes', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/processes");
-
-    var data_request = { 'function': '/experimental/syscollector/processes', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'pid': 'numbers', 'state': 'alphanumeric_param', 'ppid': 'numbers',
-        'egroup': 'alphanumeric_param',
-        'euser': 'alphanumeric_param', 'fgroup': 'alphanumeric_param',
-        'name': 'alphanumeric_param', 'nlwp': 'numbers',
-        'pgrp': 'numbers', 'priority': 'numbers',
-        'rgroup': 'alphanumeric_param', 'ruser': 'alphanumeric_param',
-        'sgroup': 'alphanumeric_param', 'suser': 'alphanumeric_param'
-    };
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('pid' in req.query)
-        data_request['arguments']['filters']['pid'] = req.query.pid;
-    if ('ppid' in req.query)
-        data_request['arguments']['filters']['ppid'] = req.query.ppid;
-    if ('egroup' in req.query)
-        data_request['arguments']['filters']['egroup'] = req.query.egroup;
-    if ('euser' in req.query)
-        data_request['arguments']['filters']['euser'] = req.query.euser;
-    if ('fgroup' in req.query)
-        data_request['arguments']['filters']['fgroup'] = req.query.fgroup;
-    if ('nlwp' in req.query)
-        data_request['arguments']['filters']['nlwp'] = req.query.nlwp;
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name;
-    if ('pgrp' in req.query)
-        data_request['arguments']['filters']['pgrp'] = req.query.pgrp;
-    if ('priority' in req.query)
-        data_request['arguments']['filters']['priority'] = req.query.priority;
-    if ('rgroup' in req.query)
-        data_request['arguments']['filters']['rgroup'] = req.query.rgroup;
-    if ('ruser' in req.query)
-        data_request['arguments']['filters']['ruser'] = req.query.ruser;
-    if ('sgroup' in req.query)
-        data_request['arguments']['filters']['sgroup'] = req.query.sgroup;
-    if ('suser' in req.query)
-        data_request['arguments']['filters']['suser'] = req.query.suser;
-
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'pid': 'numbers', 'state': 'alphanumeric_param', 'ppid': 'numbers',
+                   'egroup': 'alphanumeric_param', 'euser': 'alphanumeric_param', 
+                   'fgroup': 'alphanumeric_param', 'name': 'alphanumeric_param', 
+                   'nlwp': 'numbers', 'pgrp': 'numbers', 'priority': 'numbers',
+                   'rgroup': 'alphanumeric_param', 'ruser': 'alphanumeric_param',
+                   'sgroup': 'alphanumeric_param', 'suser': 'alphanumeric_param'
+                };
+    templates.array_request("/experimental/syscollector/processes", req, res, "syscollector", {}, filters);
 })
 
 
@@ -346,52 +171,12 @@ router.get('/syscollector/processes', function (req, res) {
  *
  */
 router.get('/syscollector/ports', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/ports");
-
-    var data_request = { 'function': '/experimental/syscollector/ports', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'protocol': 'alphanumeric_param', 'local_ip': 'alphanumeric_param',
-        'local_port': 'numbers', 'remote_ip': 'alphanumeric_param',
-        'tx_queue': 'numbers', 'state': 'alphanumeric_param',
-        'pid': 'numbers', 'process': 'alphanumeric_param'
-    };
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('protocol' in req.query)
-        data_request['arguments']['filters']['protocol'] = req.query.protocol;
-    if ('local_ip' in req.query)
-        data_request['arguments']['filters']['local_ip'] = req.query.local_ip;
-    if ('local_port' in req.query)
-        data_request['arguments']['filters']['local_port'] = req.query.local_port;
-    if ('remote_ip' in req.query)
-        data_request['arguments']['filters']['remote_ip'] = req.query.remote_ip;
-    if ('remote_port' in req.query)
-        data_request['arguments']['filters']['remote_port'] = req.query.remote_port;
-    if ('tx_queue' in req.query)
-        data_request['arguments']['filters']['tx_queue'] = req.query.tx_queue;
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('pid' in req.query)
-        data_request['arguments']['filters']['pid'] = req.query.pid;
-    if ('process' in req.query)
-        data_request['arguments']['filters']['process'] = req.query.process;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'protocol': 'alphanumeric_param', 'local_ip': 'alphanumeric_param',
+                   'local_port': 'numbers', 'remote_ip': 'alphanumeric_param',
+                   'tx_queue': 'numbers', 'state': 'alphanumeric_param',
+                   'pid': 'numbers', 'process': 'alphanumeric_param'
+                };
+    templates.array_request("/experimental/syscollector/ports", req, res, "syscollector", {}, filters);
 })
 
 
@@ -417,42 +202,10 @@ router.get('/syscollector/ports', function (req, res) {
  *
  */
 router.get('/syscollector/netaddr', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/netaddr");
-
-    var data_request = { 'function': '/experimental/syscollector/netaddr', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param', 'iface': 'alphanumeric_param',
-        'proto': 'alphanumeric_param', 'address': 'alphanumeric_param',
-        'broadcast': 'alphanumeric_param', 'netmask': 'alphanumeric_param',
-    };
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('iface' in req.query)
-        data_request['arguments']['filters']['iface'] = req.query.iface;
-    if ('proto' in req.query)
-        data_request['arguments']['filters']['proto'] = req.query.proto;
-    if ('address' in req.query)
-        data_request['arguments']['filters']['address'] = req.query.address;
-    if ('broadcast' in req.query)
-        data_request['arguments']['filters']['broadcast'] = req.query.broadcast;
-    if ('netmask' in req.query)
-        data_request['arguments']['filters']['netmask'] = req.query.netmask;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'iface': 'alphanumeric_param', 'proto': 'alphanumeric_param', 'address': 'alphanumeric_param',
+                   'broadcast': 'alphanumeric_param', 'netmask': 'alphanumeric_param',
+                };
+    templates.array_request("/experimental/syscollector/netaddr", req, res, "syscollector", {}, filters);
 })
 
 
@@ -478,40 +231,10 @@ router.get('/syscollector/netaddr', function (req, res) {
  *
  */
 router.get('/syscollector/netproto', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/netproto");
-
-    var data_request = { 'function': '/experimental/syscollector/netproto', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'iface': 'alphanumeric_param', 'type': 'alphanumeric_param',
-        'gateway': 'alphanumeric_param', 'dhcp': 'alphanumeric_param'
-    };
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('iface' in req.query)
-        data_request['arguments']['filters']['iface'] = req.query.iface;
-    if ('type' in req.query)
-        data_request['arguments']['filters']['type'] = req.query.type;
-    if ('gateway' in req.query)
-        data_request['arguments']['filters']['gateway'] = req.query.gateway;
-    if ('dhcp' in req.query)
-        data_request['arguments']['filters']['dhcp'] = req.query.dhcp;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'iface': 'alphanumeric_param', 'type': 'alphanumeric_param',
+                   'gateway': 'alphanumeric_param', 'dhcp': 'alphanumeric_param'
+                };
+    templates.array_request("/experimental/syscollector/netproto", req, res, "syscollector", {}, filters);
 })
 
 
@@ -549,59 +272,13 @@ router.get('/syscollector/netiface', function (req, res) {
     logger.debug(req.connection.remoteAddress + " GET /experimental/syscollector/netiface");
 
     var data_request = { 'function': '/experimental/syscollector/netiface', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param', 'name': 'alphanumeric_param',
-        'adapter': 'alphanumeric_param', 'type': 'alphanumeric_param',
-        'state': 'alphanumeric_param', 'mtu': 'numbers',
-         'tx_packets': 'numbers', 'rx_packets': 'numbers', 'tx_bytes': 'numbers',
-        'rx_bytes': 'numbers', 'tx_errors': 'numbers',
-        'rx_errors': 'numbers', 'tx_dropped': 'numbers',
-        'rx_dropped': 'numbers'
-    };
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name;
-    if ('adapter' in req.query)
-        data_request['arguments']['filters']['adapter'] = req.query.adapter;
-    if ('type' in req.query)
-        data_request['arguments']['filters']['type'] = req.query.type;
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('mtu' in req.query)
-        data_request['arguments']['filters']['mtu'] = req.query.mtu;
-    if ('tx_packets' in req.query)
-        data_request['arguments']['filters']['tx_packets'] = req.query.tx_packets;
-    if ('rx_packets' in req.query)
-        data_request['arguments']['filters']['rx_packets'] = req.query.rx_packets;
-    if ('tx_bytes' in req.query)
-        data_request['arguments']['filters']['tx_bytes'] = req.query.tx_bytes;
-    if ('rx_bytes' in req.query)
-        data_request['arguments']['filters']['rx_bytes'] = req.query.rx_bytes;
-    if ('tx_errors' in req.query)
-        data_request['arguments']['filters']['tx_errors'] = req.query.tx_errors;
-    if ('rx_errors' in req.query)
-        data_request['arguments']['filters']['rx_errors'] = req.query.rx_errors;
-    if ('tx_dropped' in req.query)
-        data_request['arguments']['filters']['tx_dropped'] = req.query.tx_dropped;
-    if ('rx_dropped' in req.query)
-        data_request['arguments']['filters']['rx_dropped'] = req.query.rx_dropped;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'name': 'alphanumeric_param', 'adapter': 'alphanumeric_param', 
+                   'type': 'alphanumeric_param', 'state': 'alphanumeric_param', 
+                   'mtu': 'numbers', 'tx_packets': 'numbers', 'rx_packets': 'numbers', 
+                   'tx_bytes': 'numbers', 'rx_bytes': 'numbers', 'tx_errors': 'numbers',
+                   'rx_errors': 'numbers', 'tx_dropped': 'numbers', 'rx_dropped': 'numbers'
+                };
+    templates.array_request("/experimental/syscollector/netiface", req, res, "syscollector", {}, filters);
 })
 
 

--- a/controllers/syscheck.js
+++ b/controllers/syscheck.js
@@ -31,6 +31,7 @@ var router = require('express').Router();
  * @apiParam {String} [sha1] Returns the files with the specified sha1 hash.
  * @apiParam {String} [sha256] Returns the files with the specified sha256 hash.
  * @apiParam {String} [hash] Returns the files with the specified hash (md5, sha1 or sha256).
+ * @apiParam {string} [q] Advanced query filtering
  *
  * @apiDescription Returns the syscheck files of an agent.
  *
@@ -39,53 +40,11 @@ var router = require('express').Router();
  *
  */
 router.get('/:agent_id', cache(), function(req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscheck/:agent_id");
-
-    req.apicacheGroup = "syscheck";
-
-    var data_request = {'function': '/syscheck/:agent_id', 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param',
-		'search':'search_param', 'file':'paths', 'type':'names',
-		'summary':'yes_no_boolean', 'select': 'alphanumeric_param','md5':'hashes', 'sha1':'hashes',
-		'sha256': 'hashes', 'hash':'hashes'};
-		
-	data_request.arguments['filters'] = {}
-	
-
-    if (!filter.check(req.query, filters, req, res))  // Filter with error
-        return;
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('file' in req.query)
-        data_request['arguments']['filters']['file'] = req.query.file;
-    if ('type' in req.query)
-        data_request['arguments']['filters']['type'] = req.query.type;
-    if ('summary' in req.query && req.query.summary == "yes")
-        data_request['arguments']['summary'] = req.query.summary;
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select);
-    if ('md5' in req.query)
-        data_request.arguments.filters['md5'] = req.query.md5.toLowerCase();
-    if ('sha1' in req.query)
-        data_request.arguments.filters['sha1'] = req.query.sha1.toLowerCase();
-    if ('sha256' in req.query)
-        data_request.arguments.filters['sha256'] = req.query.sha256.toLowerCase();
-    if ('hash' in req.query)
-        data_request.arguments.filters['hash'] = req.query.hash.toLowerCase();
-
-
-    if (!filter.check(req.params, {'agent_id':'numbers'}, req, res))  // Filter with error
-        return;
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
-})
+    var filters = {'file':'paths', 'type':'names', 'summary':'yes_no_boolean',
+                   'select': 'alphanumeric_param','md5':'hashes', 'sha1':'hashes',
+		           'sha256': 'hashes', 'hash':'hashes'};
+    templates.array_request("/syscheck/:agent_id", req, res, "syscheck", {'agent_id': 'numbers'}, filters);
+});
 
 
 /**

--- a/controllers/syscollector.js
+++ b/controllers/syscollector.js
@@ -28,23 +28,7 @@ var router = require('express').Router();
  *
  */
 router.get('/:agent_id/os', function(req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/os");
-
-    var data_request = {'function': '/syscollector/:agent_id/os', 'arguments': {}};
-    var filters = {'select':'select_param'};
-
-    if (!filter.check(req.params, {'agent_id':'numbers'}, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    templates.object_request("/syscollector/:agent_id/os", req, res, "syscollector", {'agent_id': 'numbers'}, {});
 })
 
 /**
@@ -62,27 +46,7 @@ router.get('/:agent_id/os', function(req, res) {
  *
  */
 router.get('/:agent_id/hardware', function(req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/hardware");
-
-    var data_request = {'function': '/syscollector/:agent_id/hardware', 'arguments': {}};
-
-    var filters = {'select':'select_param'};
-
-
-    if (!filter.check(req.params, {'agent_id':'numbers'}, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters']  = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    templates.object_request("/syscollector/:agent_id/hardware", req, res, "syscollector", {'agent_id': 'numbers'}, {});
 })
 
 /**
@@ -109,48 +73,11 @@ router.get('/:agent_id/hardware', function(req, res) {
  *
  */
 router.get('/:agent_id/packages', function(req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/packages");
-
-    var data_request = {'function': '/syscollector/:agent_id/packages', 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param',
-                   'search':'search_param', 'select':'select_param',
-                    'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
-                    'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param', 'version' : 'alphanumeric_param'};
-
-
-    if (!filter.check(req.params, {'agent_id':'numbers'}, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters']  = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('vendor' in req.query)
-        data_request['arguments']['filters']['vendor'] = req.query.vendor;
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name;
-    if ('architecture' in req.query)
-        data_request['arguments']['filters']['architecture'] = req.query.architecture;
-    if ('format' in req.query)
-        data_request['arguments']['filters']['format'] = req.query.format;
-    if ('version' in req.query)
-        data_request['arguments']['filters']['version'] = req.query.version;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'vendor': 'alphanumeric_param', 'name': 'alphanumeric_param',
+                   'architecture': 'alphanumeric_param', 'format': 'alphanumeric_param', 
+                   'version' : 'alphanumeric_param'};
+    templates.array_request("/syscollector/:agent_id/packages", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
-
 
 /**
  * @api {get} /syscollector/:agent_id/processes Get processes info
@@ -185,71 +112,14 @@ router.get('/:agent_id/packages', function(req, res) {
  *
  */
 router.get('/:agent_id/processes', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/processes");
-
-    var data_request = { 'function': '/syscollector/:agent_id/processes', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'pid': 'numbers', 'state': 'alphanumeric_param', 'ppid': 'numbers',
-        'egroup': 'alphanumeric_param',
-        'euser': 'alphanumeric_param', 'fgroup': 'alphanumeric_param',
-        'name': 'alphanumeric_param', 'nlwp': 'numbers',
-        'pgrp': 'numbers', 'priority': 'numbers',
-        'rgroup': 'alphanumeric_param', 'ruser': 'alphanumeric_param',
-        'sgroup': 'alphanumeric_param', 'suser': 'alphanumeric_param'
-    };
-
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('pid' in req.query)
-        data_request['arguments']['filters']['pid'] = req.query.pid;
-    if ('ppid' in req.query)
-        data_request['arguments']['filters']['ppid'] = req.query.ppid;
-    if ('egroup' in req.query)
-        data_request['arguments']['filters']['egroup'] = req.query.egroup;
-    if ('euser' in req.query)
-        data_request['arguments']['filters']['euser'] = req.query.euser;
-    if ('fgroup' in req.query)
-        data_request['arguments']['filters']['fgroup'] = req.query.fgroup;
-    if ('nlwp' in req.query)
-        data_request['arguments']['filters']['nlwp'] = req.query.nlwp;
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name;
-    if ('pgrp' in req.query)
-        data_request['arguments']['filters']['pgrp'] = req.query.pgrp;
-    if ('priority' in req.query)
-        data_request['arguments']['filters']['priority'] = req.query.priority;
-    if ('rgroup' in req.query)
-        data_request['arguments']['filters']['rgroup'] = req.query.rgroup;
-    if ('ruser' in req.query)
-        data_request['arguments']['filters']['ruser'] = req.query.ruser;
-    if ('sgroup' in req.query)
-        data_request['arguments']['filters']['sgroup'] = req.query.sgroup;
-    if ('suser' in req.query)
-        data_request['arguments']['filters']['suser'] = req.query.suser;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'pid': 'numbers', 'state': 'alphanumeric_param', 'ppid': 'numbers',
+                   'egroup': 'alphanumeric_param', 'euser': 'alphanumeric_param', 
+                   'fgroup': 'alphanumeric_param', 'name': 'alphanumeric_param', 
+                   'nlwp': 'numbers', 'pgrp': 'numbers', 'priority': 'numbers',
+                   'rgroup': 'alphanumeric_param', 'ruser': 'alphanumeric_param',
+                   'sgroup': 'alphanumeric_param', 'suser': 'alphanumeric_param'
+                };
+    templates.array_request("/syscollector/:agent_id/processes", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
 
 
@@ -279,59 +149,13 @@ router.get('/:agent_id/processes', function (req, res) {
  *
  */
 router.get('/:agent_id/ports', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/ports");
-
-    var data_request = { 'function': '/syscollector/:agent_id/ports', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'protocol': 'alphanumeric_param', 'local_ip': 'alphanumeric_param',
-        'local_port': 'numbers', 'remote_ip': 'alphanumeric_param',
-        'tx_queue': 'numbers', 'state': 'alphanumeric_param',
-        'pid': 'numbers', 'process': 'alphanumeric_param'
-    };
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('protocol' in req.query)
-        data_request['arguments']['filters']['protocol'] = req.query.protocol;
-    if ('local_ip' in req.query)
-        data_request['arguments']['filters']['local_ip'] = req.query.local_ip;
-    if ('local_port' in req.query)
-        data_request['arguments']['filters']['local_port'] = req.query.local_port;
-    if ('remote_ip' in req.query)
-        data_request['arguments']['filters']['remote_ip'] = req.query.remote_ip;
-    if ('remote_port' in req.query)
-        data_request['arguments']['filters']['remote_port'] = req.query.remote_port;
-    if ('tx_queue' in req.query)
-        data_request['arguments']['filters']['tx_queue'] = req.query.tx_queue;
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('pid' in req.query)
-        data_request['arguments']['filters']['pid'] = req.query.pid;
-    if ('process' in req.query)
-        data_request['arguments']['filters']['process'] = req.query.process;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'protocol': 'alphanumeric_param', 'local_ip': 'alphanumeric_param',
+                   'local_port': 'numbers', 'remote_ip': 'alphanumeric_param',
+                   'tx_queue': 'numbers', 'state': 'alphanumeric_param',
+                   'pid': 'numbers', 'process': 'alphanumeric_param'
+                  };
+    templates.array_request("/syscollector/:agent_id/ports", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
-
 
 /**
  * @api {get} /syscollector/:agent_id/netaddr Get network address info of an agent
@@ -356,49 +180,12 @@ router.get('/:agent_id/ports', function (req, res) {
  *
  */
 router.get('/:agent_id/netaddr', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/netaddr");
-
-    var data_request = { 'function': '/syscollector/:agent_id/netaddr', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param', 'iface': 'alphanumeric_param',
-        'proto': 'alphanumeric_param', 'address': 'alphanumeric_param',
-        'broadcast': 'alphanumeric_param', 'netmask': 'alphanumeric_param',
-    };
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('iface' in req.query)
-        data_request['arguments']['filters']['iface'] = req.query.iface;
-    if ('proto' in req.query)
-        data_request['arguments']['filters']['proto'] = req.query.proto;
-    if ('address' in req.query)
-        data_request['arguments']['filters']['address'] = req.query.address;
-    if ('broadcast' in req.query)
-        data_request['arguments']['filters']['broadcast'] = req.query.broadcast;
-    if ('netmask' in req.query)
-        data_request['arguments']['filters']['netmask'] = req.query.netmask;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+   var filters = {'iface': 'alphanumeric_param', 'proto': 'alphanumeric_param', 
+                  'address': 'alphanumeric_param', 'broadcast': 'alphanumeric_param',
+                  'netmask': 'alphanumeric_param'
+                };
+    templates.array_request("/syscollector/:agent_id/netaddr", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
-
 
 /**
  * @api {get} /syscollector/:agent_id/netproto Get network protocol info of an agent
@@ -422,47 +209,11 @@ router.get('/:agent_id/netaddr', function (req, res) {
  *
  */
 router.get('/:agent_id/netproto', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/netproto");
-
-    var data_request = { 'function': '/syscollector/:agent_id/netproto', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param',
-        'iface': 'alphanumeric_param', 'type': 'alphanumeric_param',
-        'gateway': 'alphanumeric_param', 'dhcp': 'alphanumeric_param',
-    };
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('iface' in req.query)
-        data_request['arguments']['filters']['iface'] = req.query.iface;
-    if ('type' in req.query)
-        data_request['arguments']['filters']['type'] = req.query.type;
-    if ('gateway' in req.query)
-        data_request['arguments']['filters']['gateway'] = req.query.gateway;
-    if ('dhcp' in req.query)
-        data_request['arguments']['filters']['dhcp'] = req.query.dhcp;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'iface': 'alphanumeric_param', 'type': 'alphanumeric_param',
+                   'gateway': 'alphanumeric_param', 'dhcp': 'alphanumeric_param'
+                  };
+    templates.array_request("/syscollector/:agent_id/netproto", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
-
 
 /**
  * @api {get} /syscollector/:agent_id/netiface Get network interface info of an agent
@@ -495,68 +246,13 @@ router.get('/:agent_id/netproto', function (req, res) {
  *
  */
 router.get('/:agent_id/netiface', function (req, res) {
-    logger.debug(req.connection.remoteAddress + " GET /syscollector/:agent_id/netiface");
-
-    var data_request = { 'function': '/syscollector/:agent_id/netiface', 'arguments': {} };
-    var filters = {
-        'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param',
-        'search': 'search_param', 'select': 'select_param', 'name': 'alphanumeric_param',
-        'adapter': 'alphanumeric_param', 'type': 'alphanumeric_param',
-        'state': 'alphanumeric_param', 'mtu': 'numbers',
-        'tx_packets': 'numbers', 'rx_packets': 'numbers', 'tx_bytes': 'numbers',
-        'rx_bytes': 'numbers', 'tx_errors': 'numbers',
-        'rx_errors': 'numbers', 'tx_dropped': 'numbers',
-        'rx_dropped': 'numbers'
-    };
-
-    if (!filter.check(req.params, { 'agent_id': 'numbers' }, req, res))  // Filter with error
-        return;
-
-    if (!filter.check(req.query, filters, req, res))
-        return;
-
-    data_request['arguments']['agent_id'] = req.params.agent_id;
-    data_request['arguments']['filters'] = {};
-
-    if ('select' in req.query)
-        data_request['arguments']['select'] = filter.select_param_to_json(req.query.select)
-    if ('offset' in req.query)
-        data_request['arguments']['offset'] = Number(req.query.offset);
-    if ('limit' in req.query)
-        data_request['arguments']['limit'] = Number(req.query.limit);
-    if ('sort' in req.query)
-        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
-    if ('search' in req.query)
-        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
-    if ('name' in req.query)
-        data_request['arguments']['filters']['name'] = req.query.name;
-    if ('adapter' in req.query)
-        data_request['arguments']['filters']['adapter'] = req.query.adapter;
-    if ('type' in req.query)
-        data_request['arguments']['filters']['type'] = req.query.type;
-    if ('state' in req.query)
-        data_request['arguments']['filters']['state'] = req.query.state;
-    if ('mtu' in req.query)
-        data_request['arguments']['filters']['mtu'] = req.query.mtu;
-    if ('tx_packets' in req.query)
-        data_request['arguments']['filters']['tx_packets'] = req.query.tx_packets;
-    if ('rx_packets' in req.query)
-        data_request['arguments']['filters']['rx_packets'] = req.query.rx_packets;
-    if ('tx_bytes' in req.query)
-        data_request['arguments']['filters']['tx_bytes'] = req.query.tx_bytes;
-    if ('rx_bytes' in req.query)
-        data_request['arguments']['filters']['rx_bytes'] = req.query.rx_bytes;
-    if ('tx_errors' in req.query)
-        data_request['arguments']['filters']['tx_errors'] = req.query.tx_errors;
-    if ('rx_errors' in req.query)
-        data_request['arguments']['filters']['rx_errors'] = req.query.rx_errors;
-    if ('tx_dropped' in req.query)
-        data_request['arguments']['filters']['tx_dropped'] = req.query.tx_dropped;
-    if ('rx_dropped' in req.query)
-        data_request['arguments']['filters']['rx_dropped'] = req.query.rx_dropped;
-
-    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+    var filters = {'name': 'alphanumeric_param', 'adapter': 'alphanumeric_param',
+                   'type': 'alphanumeric_param', 'state': 'alphanumeric_param', 
+                   'mtu': 'numbers', 'tx_packets': 'numbers', 'rx_packets': 'numbers', 
+                   'tx_bytes': 'numbers', 'rx_bytes': 'numbers', 'tx_errors': 'numbers',
+                   'rx_errors': 'numbers', 'tx_dropped': 'numbers', 'rx_dropped': 'numbers'
+                  };
+    templates.array_request("/syscollector/:agent_id/netiface", req, res, "syscollector", {'agent_id': 'numbers'}, filters);
 })
-
 
 module.exports = router;

--- a/helpers/request_templates.js
+++ b/helpers/request_templates.js
@@ -23,7 +23,7 @@
     * param_checks -> Input validation checks for arguments in req.params.
     * query_checks -> Input validation checks for arguments in req.query.
  */
-exports.single_field_array_request = function(entrypoint_name, req, res, apicacheGroup, param_checks, query_checks) {
+exports.single_field_array_request = function(entrypoint_name, req, res, apicacheGroup, param_checks, query_checks, single_object=false) {
     if(!param_checks || typeof param_checks !== 'object'){
         param_checks = {};
     }
@@ -37,8 +37,11 @@ exports.single_field_array_request = function(entrypoint_name, req, res, apicach
     req.apicacheGroup = apicacheGroup;
 
     var data_request = {'function': entrypoint_name, 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param',
-                   'search':'search_param', 'q':'query_param'};
+    if (single_object)
+        var filters = {}
+    else
+        var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 
+                       'search':'search_param', 'q':'query_param'};
 
     if (!filter.check(req.query, Object.assign({}, filters, query_checks), req, res))  // Filter with error
         return;
@@ -82,7 +85,7 @@ exports.single_field_array_request = function(entrypoint_name, req, res, apicach
         GET/agents
         GET/rootcheck/:agent_id
  */
-exports.array_request = function (entrypoint_name, req, res, apicacheGroup, param_checks, query_checks) {
+exports.array_request = function (entrypoint_name, req, res, apicacheGroup, param_checks, query_checks, single_object=false) {
     if(!param_checks || typeof param_checks !== 'object'){
         param_checks = {};
     }
@@ -91,5 +94,12 @@ exports.array_request = function (entrypoint_name, req, res, apicacheGroup, para
         query_checks = {};
     }
     query_checks['select'] = 'select_param';
-    this.single_field_array_request(entrypoint_name, req, res, apicacheGroup, param_checks, query_checks);
+    this.single_field_array_request(entrypoint_name, req, res, apicacheGroup, param_checks, query_checks, single_object);
+}
+
+/*
+    Function used in API requests that return a single object.
+*/
+exports.object_request = function(entrypoint_name, req, res, apiCacheGroup, param_checks, query_checks) {
+    this.array_request(entrypoint_name, req, res, apiCacheGroup, param_checks, query_checks, true);
 }

--- a/test/test_syscollector.js
+++ b/test/test_syscollector.js
@@ -77,7 +77,8 @@ describe('Syscollector', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.should.have.properties(['os_version', 'sysname', 'release']);
+                    res.body.data.should.have.properties(['os', 'sysname', 'release']);
+                    res.body.data.os.should.have.properties(['version']);
                     done();
                 });
         });
@@ -134,8 +135,9 @@ describe('Syscollector', function () {
                     res.body.should.have.properties(['error', 'data']);
 
                     res.body.error.should.equal(0);
-                    res.body.data.should.have.properties(['board_serial', 'ram', 'cpu_name']);
+                    res.body.data.should.have.properties(['board_serial', 'ram', 'cpu']);
                     res.body.data.ram.should.have.properties(['free', 'total']);
+                    res.body.data.cpu.should.have.properties(['name']);
                     done();
                 });
         });
@@ -192,7 +194,8 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['description', 'architecture', 'scan_id']);
+                    res.body.data.items[0].should.have.properties(['description', 'architecture', 'scan']);
+                    res.body.data.items[0].scan.should.have.properties(['id']);
                     done();
                 });
         });
@@ -501,6 +504,23 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function(done) {
+            request(common.url)
+                .get('/syscollector/' + agent_id + '/packages?q=format=' + expected_format + ',architecture!=' + expected_architecture)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['format']);
+                    res.body.data.items[0].format.should.be.equal(expected_format);
+                    done();
+                });
+        });
     });  // GET/syscollector/:agent_id/packages
 
 
@@ -848,6 +868,24 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function(done) {
+            request(common.url)
+                .get('/experimental/syscollector/packages?q=format=' + expected_format + ',architecture!=' + expected_architecture + ',(size>1000;size<2000)')
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['format']);
+                    res.body.data.items[0].format.should.be.equal(expected_format);
+                    done();
+                });
+        });
+
     });  // GET/syscollector/packages
 
 
@@ -887,7 +925,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['sysname', 'version', 'release', 'os_version']);
+                    res.body.data.items[0].should.have.properties(['sysname', 'version', 'release', 'os']);
                     done();
                 });
         });
@@ -1121,6 +1159,24 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/os?q=release=" + expected_release + ';os_major>16')
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].should.have.properties(['release']);
+                    res.body.data.items[0].release.should.be.equal(expected_release);
+                    done();
+                });
+        });
+
     });  // GET/experimental/syscollector/os
 
     describe('GET/experimental/syscollector/hardware', function () {
@@ -1146,7 +1202,7 @@ describe('Syscollector', function () {
 
         it('Selector', function (done) {
             request(common.url)
-                .get("/experimental/syscollector/hardware?select=ram_free,board_serial,cpu_name,agent_id,cpu_mhz")
+                .get("/experimental/syscollector/hardware?select=ram_free,board_serial,cpu_name,cpu_mhz")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -1158,7 +1214,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['ram_free', 'board_serial', 'cpu', 'agent_id', 'cpu']);
+                    res.body.data.items[0].should.have.properties(['ram', 'board_serial', 'cpu', 'agent_id', 'cpu']);
                     res.body.data.items[0].cpu.should.have.properties(['mhz','name']);
                     done();
                 });
@@ -1403,6 +1459,24 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/hardware?q=cpu_cores>0;ram_usage<1000")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.error.should.equal(0);
+                    res.body.data.totalItems.should.be.above(0);
+                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items[0].cpu.cores.should.be.above(0);
+                    res.body.data.items[0].cpu.cores.should.be.below(1000);
+                    done();
+                });
+        });
+
     });  // GET experimental/syscollector/hardware
 
 
@@ -1447,7 +1521,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['tty', 'sgroup', 'share', 'session', 'scan_id']);
+                    res.body.data.items[0].should.have.properties(['tty', 'sgroup', 'share', 'session', 'scan']);
                     done();
                 });
         });
@@ -1784,9 +1858,21 @@ describe('Syscollector', function () {
                 });
         });
 
-
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/processes?limit=2&offset=1&q=suser!=" + expected_suser)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(processes_properties);
+                    res.body.data.items[0].suser.should.not.be.equal(expected_suser);
+                    done();
+                });
+        });
     });  // GET/syscollector/processes
-
 
 
     ports_properties = ['scan', 'protocol', 'local', 'remote', 'tx_queue',
@@ -1826,7 +1912,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['protocol', 'remote_ip', 'tx_queue', 'state']);
+                    res.body.data.items[0].should.have.properties(['protocol', 'remote', 'tx_queue', 'state']);
                     done();
                 });
         });
@@ -2044,13 +2130,24 @@ describe('Syscollector', function () {
                 });
         });
 
-
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/ports?q=state!=" + expected_state + ';tx_queue>100')
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    done();
+                });
+        });
 
     });  // GET/experimental/syscollector/ports
 
 
     describe('GET/syscollector/netaddr', function () {
-        netaddr_properties = ['scan_id', 'iface', 'proto', 'address', 'netmask', 'broadcast', 'agent_id']
+        netaddr_properties = ['scan', 'iface', 'proto', 'address', 'netmask', 'broadcast', 'agent_id']
 
         it('Request', function (done) {
             request(common.url)
@@ -2286,10 +2383,25 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/netaddr?q=netmask=" + expected_netmask)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(netaddr_properties);
+                    res.body.data.items[0].netmask.should.be.equal(expected_netmask);
+                    done();
+                });
+        });
+
     });  // GET/syscollector/netaddr
 
     describe('GET/experimental/syscollector/netproto', function () {
-        netproto_properties = ['scan_id', 'iface', 'type', 'gateway', 'dhcp']
+        netproto_properties = ['scan', 'iface', 'type', 'gateway', 'dhcp']
 
         it('Request', function (done) {
             request(common.url)
@@ -2450,7 +2562,7 @@ describe('Syscollector', function () {
 
         it('Filter: iface', function (done) {
             request(common.url)
-                .get("/experimental/syscollector/netproto?=" + expected_proto)
+                .get("/experimental/syscollector/netproto?iface=" + expected_iface)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -2465,7 +2577,7 @@ describe('Syscollector', function () {
 
         it('Filter: type', function (done) {
             request(common.url)
-                .get("/experimental/syscollector/netproto?=" + expected_proto)
+                .get("/experimental/syscollector/netproto?type=" + expected_type)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -2480,7 +2592,7 @@ describe('Syscollector', function () {
 
         it('Filter: gateway', function (done) {
             request(common.url)
-                .get("/experimental/syscollector/netproto?=" + expected_proto)
+                .get("/experimental/syscollector/netproto?gateway=" + expected_gateway)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -2495,7 +2607,7 @@ describe('Syscollector', function () {
 
         it('Filter: dhcp', function (done) {
             request(common.url)
-                .get("/experimental/syscollector/netproto?=" + expected_proto)
+                .get("/experimental/syscollector/netproto?dhcp=" + expected_dhcp)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -2504,6 +2616,20 @@ describe('Syscollector', function () {
                     res.body.should.have.properties(['error', 'data']);
                     res.body.data.items[0].should.have.properties(netproto_properties);
                     res.body.data.items[0].dhcp.should.be.equal(expected_dhcp);
+                    done();
+                });
+        });
+
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/netproto?q=type=ipv6,dhcp=enabled")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(netproto_properties);
                     done();
                 });
         });
@@ -2870,6 +2996,18 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/experimental/syscollector/netiface?q=rx_dropped>" + expected_rx_dropped)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    done();
+                });
+        });
 
     });  // GET/syscollector/netiface
 
@@ -2914,7 +3052,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['tty', 'sgroup', 'share', 'session', 'scan_id']);
+                    res.body.data.items[0].should.have.properties(['tty', 'sgroup', 'share', 'session', 'scan']);
                     done();
                 });
         });
@@ -3251,6 +3389,20 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/syscollector/" + agent_id + "/processes?q=suser!=" + expected_suser)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(processes_properties);
+                    res.body.data.items[0].suser.should.not.be.equal(expected_suser);
+                    done();
+                });
+        });
 
     });  // GET/syscollector/:agent_id/processes
 
@@ -3289,7 +3441,7 @@ describe('Syscollector', function () {
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
                     res.body.data.items.should.be.instanceof(Array)
-                    res.body.data.items[0].should.have.properties(['protocol', 'remote_ip', 'tx_queue', 'state']);
+                    res.body.data.items[0].should.have.properties(['protocol', 'remote', 'tx_queue', 'state']);
                     done();
                 });
         });
@@ -3507,7 +3659,20 @@ describe('Syscollector', function () {
                 });
         });
 
-
+        it('Query', function (done) {
+            request(common.url)
+                .get("/syscollector/" + agent_id + "/ports?q=state=" + expected_state)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(ports_properties);
+                    res.body.data.items[0].state.should.be.equal(expected_state);
+                    done();
+                });
+        });
 
     });  // GET/syscollector/:agent_id/ports
 
@@ -3749,10 +3914,25 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/syscollector/" + agent_id + "/netaddr?q=netmask=" + expected_netmask)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    res.body.data.items[0].should.have.properties(netaddr_properties);
+                    res.body.data.items[0].netmask.should.be.equal(expected_netmask);
+                    done();
+                });
+        });
+
     });  // GET/syscollector/:agent_id/netaddr
 
     describe('GET/syscollector/' + agent_id + '/netproto', function () {
-        netproto_properties = ['scan_id', 'iface', 'type', 'gateway', 'dhcp']
+        netproto_properties = ['scan', 'iface', 'type', 'gateway', 'dhcp']
 
         it('Request', function (done) {
             request(common.url)
@@ -3913,7 +4093,7 @@ describe('Syscollector', function () {
 
         it('Filter: iface', function (done) {
             request(common.url)
-                .get("/syscollector/" + agent_id + "/netproto?=" + expected_proto)
+                .get("/syscollector/" + agent_id + "/netproto?iface=" + expected_iface)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -3928,7 +4108,7 @@ describe('Syscollector', function () {
 
         it('Filter: type', function (done) {
             request(common.url)
-                .get("/syscollector/" + agent_id + "/netproto?=" + expected_proto)
+                .get("/syscollector/" + agent_id + "/netproto?type=" + expected_type)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -3943,7 +4123,7 @@ describe('Syscollector', function () {
 
         it('Filter: gateway', function (done) {
             request(common.url)
-                .get("/syscollector/" + agent_id + "/netproto?=" + expected_proto)
+                .get("/syscollector/" + agent_id + "/netproto?gateway=" + expected_gateway)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -3958,7 +4138,7 @@ describe('Syscollector', function () {
 
         it('Filter: dhcp', function (done) {
             request(common.url)
-                .get("/syscollector/" + agent_id + "/netproto?=" + expected_proto)
+                .get("/syscollector/" + agent_id + "/netproto?dhcp=" + expected_dhcp)
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -3967,6 +4147,19 @@ describe('Syscollector', function () {
                     res.body.should.have.properties(['error', 'data']);
                     res.body.data.items[0].should.have.properties(netproto_properties);
                     res.body.data.items[0].dhcp.should.be.equal(expected_dhcp);
+                    done();
+                });
+        });
+
+        it('Query', function (done) {
+            request(common.url)
+                .get("/syscollector/" + agent_id + "/netproto?q=dhcp!=" + expected_dhcp)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
                     done();
                 });
         });
@@ -4333,6 +4526,18 @@ describe('Syscollector', function () {
                 });
         });
 
+        it('Query', function (done) {
+            request(common.url)
+                .get("/syscollector/" + agent_id + "/netiface?q=rx_dropped>" + expected_rx_dropped)
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+                    res.body.should.have.properties(['error', 'data']);
+                    done();
+                });
+        });
 
     });  // GET/syscollector/:agent_id/netiface
 


### PR DESCRIPTION
Hello team,

This PR adds API support for https://github.com/wazuh/wazuh/pull/2973.

Tests:
```javascript
  Syscollector
    GET/syscollector/:agent_id/os
      ✓ Request (564ms)
      ✓ Selector (566ms)
      ✓ Not allowed selector (565ms)
    GET/syscollector/:agent_id/hardware
      ✓ Request (565ms)
      ✓ Selector (674ms)
      ✓ Not allowed selector (714ms)
    GET/syscollector/:agent_id/packages
      ✓ Request (750ms)
      ✓ Selector (605ms)
      ✓ Not allowed selector (558ms)
      ✓ Pagination (568ms)
      ✓ Wrong limit
      ✓ Sort - (586ms)
      ✓ Sort + (697ms)
      ✓ Wrong Sort (1083ms)
      ✓ Search (986ms)
      1) Filter: vendor
      ✓ Filter: name (605ms)
      ✓ Filter: architecture (735ms)
      ✓ Filter: format (677ms)
      ✓ Wrong filter
      ✓ Query (773ms)
    GET/experimental/syscollector/packages
      ✓ Request (735ms)
      ✓ Selector (358ms)
      ✓ Not allowed selector (313ms)
      ✓ Pagination (281ms)
      ✓ Wrong limit
      ✓ Sort - (293ms)
      ✓ Sort + (288ms)
      ✓ Wrong Sort (290ms)
      ✓ Search (657ms)
      2) Filter: vendor
      ✓ Filter: name (406ms)
      ✓ Filter: architecture (585ms)
      ✓ Filter: format (626ms)
      ✓ Wrong filter
      ✓ Query (492ms)
    GET/experimental/syscollector/os
      ✓ Request (311ms)
      ✓ Selector (300ms)
      ✓ Not allowed selector (280ms)
      ✓ Pagination (288ms)
      ✓ Wrong limit
      ✓ Search (327ms)
      ✓ Wrong filter
      ✓ Filter: architecture (313ms)
      ✓ Filter: os_name (303ms)
      ✓ Filter: release (326ms)
      ✓ Query (303ms)
    GET/experimental/syscollector/hardware
      ✓ Request (288ms)
      ✓ Selector (297ms)
      ✓ Not allowed selector (340ms)
      ✓ Pagination (381ms)
      ✓ Wrong limit
      ✓ Search (342ms)
      ✓ Wrong filter
      ✓ Wrong Sort (306ms)
      ✓ Filter: ram_total (347ms)
      ✓ Filter: cpu_cores (585ms)
      ✓ Filter: cpu_mhz (561ms)
      ✓ Filter: board_serial (390ms)
      ✓ Query (373ms)
    GET/experimental/syscollector/processes
      ✓ Request (526ms)
      ✓ Selector (370ms)
      ✓ Not allowed selector (296ms)
      ✓ Pagination (306ms)
      ✓ Wrong limit
      ✓ Search (591ms)
      ✓ Wrong filter
      ✓ Wrong Sort (381ms)
      ✓ Filter: state (360ms)
      ✓ Filter: ppid (380ms)
      ✓ Filter: egroup (321ms)
      ✓ Filter: euser (373ms)
      ✓ Filter: fgroup (342ms)
      ✓ Filter: name (322ms)
      ✓ Filter: nlwp (309ms)
      ✓ Filter: pgrp (397ms)
      ✓ Filter: priority (346ms)
      ✓ Filter: rgroup (323ms)
      ✓ Filter: ruser (326ms)
      ✓ Filter: sgroup (310ms)
      ✓ Filter: suser (338ms)
      ✓ Query (308ms)
    GET/experimental/syscollector/ports
      ✓ Request (317ms)
      ✓ Selector (341ms)
      ✓ Not allowed selector (341ms)
      ✓ Pagination (444ms)
      ✓ Wrong limit
      ✓ Search (430ms)
      ✓ Wrong filter
      ✓ Wrong Sort (296ms)
      ✓ Filter: protocol (348ms)
      ✓ Filter: local_ip (323ms)
      ✓ Filter: local_port (354ms)
      ✓ Filter: remote_ip (307ms)
      ✓ Filter: tx_queue (323ms)
      ✓ Filter: state (369ms)
      ✓ Query (335ms)
    GET/syscollector/netaddr
      ✓ Request (310ms)
      ✓ Selector (281ms)
      ✓ Not allowed selector (272ms)
      ✓ Pagination (289ms)
      ✓ Wrong limit
      ✓ Search (307ms)
      ✓ Wrong filter
      ✓ Wrong Sort (291ms)
      ✓ Filter: iface (297ms)
      ✓ Filter: proto (307ms)
      ✓ Filter: address (299ms)
      ✓ Filter: broadcast (290ms)
      ✓ Filter: netmask (291ms)
      ✓ Query (280ms)
    GET/experimental/syscollector/netproto
      ✓ Request (323ms)
      ✓ Selector (368ms)
      ✓ Not allowed selector (305ms)
      ✓ Pagination (328ms)
      ✓ Wrong limit
      ✓ Search (323ms)
      ✓ Wrong filter
      ✓ Wrong Sort (313ms)
      ✓ Filter: iface (309ms)
      ✓ Filter: type (319ms)
      ✓ Filter: gateway (330ms)
      ✓ Filter: dhcp (329ms)
      ✓ Query (361ms)
    GET/experimental/syscollector/netiface
      ✓ Request (402ms)
      ✓ Selector (411ms)
      ✓ Not allowed selector (342ms)
      ✓ Pagination (431ms)
      ✓ Wrong limit
      ✓ Search (422ms)
      ✓ Wrong filter
      ✓ Wrong Sort (465ms)
      ✓ Filter: name (507ms)
      ✓ Filter: type (431ms)
      ✓ Filter: state (535ms)
      ✓ Filter: mtu (438ms)
      ✓ Filter: tx_packets (462ms)
      ✓ Filter: rx_packets (433ms)
      ✓ Filter: tx_bytes (765ms)
      ✓ Filter: rx_bytes (645ms)
      ✓ Filter: tx_errors (640ms)
      ✓ Filter: rx_errors (677ms)
      ✓ Filter: tx_dropped (693ms)
      ✓ Filter: rx_dropped (399ms)
      ✓ Query (325ms)
    GET/syscollector/000/processes
      ✓ Request (306ms)
      ✓ Selector (272ms)
      ✓ Not allowed selector (261ms)
      ✓ Pagination (272ms)
      ✓ Wrong limit
      ✓ Search (312ms)
      ✓ Wrong filter
      ✓ Wrong Sort (281ms)
      ✓ Filter: state (280ms)
      ✓ Filter: ppid (294ms)
      ✓ Filter: egroup (285ms)
      ✓ Filter: euser (284ms)
      ✓ Filter: fgroup (278ms)
      ✓ Filter: name (282ms)
      ✓ Filter: nlwp (285ms)
      ✓ Filter: pgrp (292ms)
      ✓ Filter: priority (279ms)
      ✓ Filter: rgroup (288ms)
      ✓ Filter: ruser (285ms)
      ✓ Filter: sgroup (288ms)
      ✓ Filter: suser (279ms)
      ✓ Query (300ms)
    GET/syscollector/000/ports
      ✓ Request (291ms)
      ✓ Selector (311ms)
      ✓ Not allowed selector (295ms)
      ✓ Pagination (278ms)
      ✓ Wrong limit
      ✓ Search (345ms)
      ✓ Wrong filter
      ✓ Wrong Sort (444ms)
      ✓ Filter: protocol (286ms)
      ✓ Filter: local_ip (426ms)
      ✓ Filter: local_port (365ms)
      ✓ Filter: remote_ip (430ms)
      ✓ Filter: tx_queue (282ms)
      ✓ Filter: state (293ms)
      ✓ Query (439ms)
    GET/syscollector/000/netaddr
      ✓ Request (340ms)
      ✓ Selector (314ms)
      ✓ Not allowed selector (291ms)
      ✓ Pagination (399ms)
      ✓ Wrong limit
      ✓ Search (478ms)
      ✓ Wrong filter
      ✓ Wrong Sort (462ms)
      ✓ Filter: iface (414ms)
      ✓ Filter: proto (570ms)
      ✓ Filter: address (618ms)
      ✓ Filter: broadcast (578ms)
      ✓ Filter: netmask (610ms)
      ✓ Query (681ms)
    GET/syscollector/000/netproto
      ✓ Request (330ms)
      ✓ Selector (321ms)
      ✓ Not allowed selector (317ms)
      ✓ Pagination (316ms)
      ✓ Wrong limit
      ✓ Search (430ms)
      ✓ Wrong filter
      ✓ Wrong Sort (666ms)
      ✓ Filter: iface (534ms)
      ✓ Filter: type (500ms)
      ✓ Filter: gateway (320ms)
      ✓ Filter: dhcp (301ms)
      ✓ Query (294ms)
    GET/syscollector/000/netiface
      ✓ Request (303ms)
      ✓ Selector (313ms)
      ✓ Not allowed selector (494ms)
      ✓ Pagination (299ms)
      ✓ Wrong limit
      ✓ Search (284ms)
      ✓ Wrong filter
      ✓ Wrong Sort (279ms)
      ✓ Filter: name (304ms)
      ✓ Filter: type (323ms)
      ✓ Filter: state (279ms)
      ✓ Filter: mtu (286ms)
      ✓ Filter: tx_packets (395ms)
      ✓ Filter: rx_packets (469ms)
      ✓ Filter: tx_bytes (319ms)
      ✓ Filter: rx_bytes (358ms)
      ✓ Filter: tx_errors (415ms)
      ✓ Filter: rx_errors (322ms)
      ✓ Filter: tx_dropped (302ms)
      ✓ Filter: rx_dropped (276ms)
      ✓ Query (288ms)


  228 passing (2m)
  2 failing

  1) Syscollector
       GET/syscollector/:agent_id/packages
         Filter: vendor:
     Error: expected 200 "OK", got 400 "Bad Request"
      at Test._assertStatus (/home/vagrant/node_modules/supertest/lib/test.js:268:12)
      at Test._assertFunction (/home/vagrant/node_modules/supertest/lib/test.js:283:11)
      at Test.assert (/home/vagrant/node_modules/supertest/lib/test.js:173:18)
      at localAssert (/home/vagrant/node_modules/supertest/lib/test.js:131:12)
      at /home/vagrant/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (/home/vagrant/node_modules/superagent/lib/node/index.js:728:3)
      at parser (/home/vagrant/node_modules/superagent/lib/node/index.js:916:18)
      at IncomingMessage.res.on (/home/vagrant/node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)

  2) Syscollector
       GET/experimental/syscollector/packages
         Filter: vendor:
     Error: expected 200 "OK", got 400 "Bad Request"
      at Test._assertStatus (/home/vagrant/node_modules/supertest/lib/test.js:268:12)
      at Test._assertFunction (/home/vagrant/node_modules/supertest/lib/test.js:283:11)
      at Test.assert (/home/vagrant/node_modules/supertest/lib/test.js:173:18)
      at localAssert (/home/vagrant/node_modules/supertest/lib/test.js:131:12)
      at /home/vagrant/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (/home/vagrant/node_modules/superagent/lib/node/index.js:728:3)
      at parser (/home/vagrant/node_modules/superagent/lib/node/index.js:916:18)
      at IncomingMessage.res.on (/home/vagrant/node_modules/superagent/lib/node/parsers/json.js:19:7)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:139:11)
      at process._tickCallback (internal/process/next_tick.js:181:9)
```

Best regards,
Marta