### PR TITLE
Add GET/{manager,cluster/:node_id}/config/:component/:configuration endpoints

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -744,7 +744,7 @@ router.get('/:node_id/configuration/validation', cache(), function(req, res) {
 router.get('/:node_id/config/:component/:configuration', cache(), function(req, res) {
     logger.debug(req.connection.remoteAddress + " GET /cluster/:node_id/config/:component/:configuration");
 
-    req.apicacheGroup = "manager";
+    req.apicacheGroup = "cluster";
 
     var data_request = {'function': '/cluster/:node_id/config/:component/:configuration', 'arguments': {}};
     var filters = {'component':'names', 'configuration': 'names', 'node_id': 'names'};

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -727,5 +727,36 @@ router.get('/:node_id/configuration/validation', cache(), function(req, res) {
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 
+/**
+ * @api {get} /cluster/:node_id/config/:component/:configuration Get active configuration in node node_id
+ * @apiName GetClusterNodeActiveConfiguration
+ * @apiGroup Configuration
+ *
+ * @apiParam {String="agent","agentless","analysis","auth","com","csyslog","integrator","logcollector","mail","monitor","request","syscheck","wmodules"} [component] Indicates the wazuh component to check.
+ * @apiParam {String="client","buffer","labels","internal","agentless","global","active_response","alerts","command","rules","decoders","internal","auth","active-response","internal","cluster","csyslog","integration","localfile","socket","remote","syscheck","rootcheck","wmodules"} [configuration] Indicates a configuration to check in the component.
+ *
+ * @apiDescription Returns the requested configuration in JSON format.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/:node_id/config/logcollector/internal?pretty"
+ *
+ */
+router.get('/:node_id/config/:component/:configuration', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /cluster/:node_id/config/:component/:configuration");
+
+    req.apicacheGroup = "manager";
+
+    var data_request = {'function': '/cluster/:node_id/config/:component/:configuration', 'arguments': {}};
+    var filters = {'component':'names', 'configuration': 'names', 'node_id': 'names'};
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['component'] = req.params.component;
+    data_request['arguments']['config'] = req.params.configuration;
+    data_request['arguments']['node_id'] = req.params.node_id;
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
 
 module.exports = router;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -55,6 +55,37 @@ router.get('/info', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /manager/config/:component/:configuration Get manager active configuration
+ * @apiName GetManagerActiveConfiguration
+ * @apiGroup Configuration
+ *
+ * @apiParam {String="agent","agentless","analysis","auth","com","csyslog","integrator","logcollector","mail","monitor","request","syscheck","wmodules"} [component] Indicates the wazuh component to check.
+ * @apiParam {String="client","buffer","labels","internal","agentless","global","active_response","alerts","command","rules","decoders","internal","auth","active-response","internal","cluster","csyslog","integration","localfile","socket","remote","syscheck","rootcheck","wmodules"} [configuration] Indicates a configuration to check in the component.
+ *
+ * @apiDescription Returns the requested configuration in JSON format.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/config/logcollector/internal?pretty"
+ *
+ */
+router.get('/config/:component/:configuration', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /manager/config/:component/:configuration");
+
+    req.apicacheGroup = "manager";
+
+    var data_request = {'function': '/manager/config/:component/:configuration', 'arguments': {}};
+    var filters = {'component':'names', 'configuration': 'names'};
+
+    if (!filter.check(req.params, filters, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['component'] = req.params.component;
+    data_request['arguments']['config'] = req.params.configuration;
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {get} /manager/configuration Get manager configuration
  * @apiName GetManagerConfiguration
  * @apiGroup Configuration

--- a/test/environment/vagrant/ossec_master.conf
+++ b/test/environment/vagrant/ossec_master.conf
@@ -102,6 +102,16 @@
     <queue_size>1024</queue_size>
   </wodle>
 
+  <wodle name="cis-cat">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <java_path>wodles/java</java_path>
+    <ciscat_path>wodles/ciscat</ciscat_path>
+  </wodle>
+
   <!-- File integrity monitoring -->
   <syscheck>
     <disabled>no</disabled>

--- a/test/environment/vagrant/ossec_master.conf
+++ b/test/environment/vagrant/ossec_master.conf
@@ -112,6 +112,19 @@
     <ciscat_path>wodles/ciscat</ciscat_path>
   </wodle>
 
+  <sca>
+    <enabled>yes</enabled>
+    <scan_on_start>yes</scan_on_start>
+    <interval>12h</interval>
+    <skip_nfs>yes</skip_nfs>
+
+    <policies>
+      <policy>cis_debian_linux_rcl.yml</policy>
+      <policy>system_audit_rcl.yml</policy>
+      <policy>system_audit_ssh.yml</policy>
+    </policies>
+  </sca>
+
   <!-- File integrity monitoring -->
   <syscheck>
     <disabled>no</disabled>

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1700,7 +1700,7 @@ describe('Cluster', function () {
             });
         });
 
-    });  // DELETE/manager/files
+    });  // DELETE/cluster/master/files
 
     describe('PUT/cluster/:node_id/restart', function() {
 
@@ -1741,5 +1741,494 @@ describe('Cluster', function () {
         });
     });  // PUT/cluster/:node_id/restart
 
+
+    describe('GET/cluster/master/config/:component/:configuration', function () {
+
+		// agentless
+		it('Request-Agentless-Agentless', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/agentless/agentless")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('agentless'); // returns an array
+                res.body.data.agentless[0].should.have.properties(['state', 'host',
+                'frequency', 'arguments', 'type', 'port']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // analysis
+		it('Request-Analysis-Global', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/analysis/global")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['global']);
+                res.body.data.global.should.have.properties(['email_notification', 'max_output_size',
+                'alerts_log', 'zeromq_output', 'host_information', 'jsonout_output', 'rotate_interval',
+                'rootkit_detection', 'integrity_checking', 'memory_size', 'logall', 'prelude_output',
+                'stats', 'white_list', 'logall_json']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Active-response', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/analysis/active_response")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                // res.body.data.should.have.properties(['active_response']); // empty list
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Alerts', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/analysis/alerts")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['alerts']);
+                res.body.data.alerts.should.have.properties(['email_alert_level', 'log_alert_level']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Command', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/analysis/command")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('command');
+                res.body.data.command[0].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[1].should.have.properties(['executable', 'timeout_allowed',
+                'name']);
+                res.body.data.command[2].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[3].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[4].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[5].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/analysis/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties(['analysisd']);
+                res.body.data.internal.analysisd.should.have.properties(['label_cache_maxage',
+                'stats_percent_diff', 'show_hidden_labels', 'decoder_order_size',
+                'min_rotate_interval', 'stats_mindiff', 'log_fw', 'rlimit_nofile', 'fts_list_size',
+                'debug', 'fts_min_size_for_str', 'default_timeframe', 'stats_maxdiff']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // auth
+		it('Request-Auth-Auth', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/auth/auth")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('auth');
+                res.body.data.auth.should.have.properties(['purge', 'ssl_auto_negotiate', 'ciphers',
+                'force_insert', 'ssl_verify_host', 'limit_maxagents', 'force_time',
+                'ssl_manager_key', 'disabled', 'ssl_manager_cert', 'use_source_ip',
+                'use_password', 'port']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // com
+		it('Request-Com-Active-response', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/com/active-response")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['active-response']);
+                res.body.data['active-response'].should.have.properties(['disabled', 'ca_verification']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Com-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/com/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['internal']);
+                res.body.data.internal.should.have.properties(['execd']);
+                res.body.data.internal.execd.should.have.properties(['request_timeout', 'max_restart_lock']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // csyslog
+		it('Request-Csyslog-Csyslog', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/csyslog/csyslog")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['syslog_output']);
+                res.body.data['syslog_output'][0].should.have.properties(['format',
+                'level', 'use_fqdn', 'port', 'server']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // integrator
+		it('Request-Integrator-Integration', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/integrator/integration")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('integration');
+                res.body.data.integration[0].should.have.properties(['alert_format', 'hook_url',
+                'group', 'name', 'level']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // logcollector  // fails without any motive
+		it('Request-Logcollector-Localfile', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/logcollector/localfile")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('localfile');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Logcollector-Socket', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/logcollector/socket")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                // res.body.should.have.properties(['error', 'data']); // data property is empty
+                // res.body.data.should.have.properties(['socket']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Logcollector-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/logcollector/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('logcollector');
+				res.body.data.internal.logcollector.should.have.properties(['open_attempts', 'input_threads',
+                'vcheck_files', 'max_files', 'sock_fail_time', 'queue_size', 'max_lines', 'remote_commands',
+                'loop_timeout', 'debug', 'open_attempts']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // mail
+		it('Request-Mail-Global', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/mail/global")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('global');
+                res.body.data.global.should.have.properties(['email_maxperhour', 'email_to',
+                'email_from', 'smtp_server']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Mail-Alerts', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/mail/alerts")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                // res.body.should.have.properties(['error', 'data']); // data property is empty
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Mail-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/mail/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('mail');
+                res.body.data.internal.mail.should.have.properties(['strict_checking',
+                'grouping']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // monitor
+		it('Request-Monitor-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/monitor/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('monitord');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // request
+		it('Request-Request-Remote', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/request/remote")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('remote');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Request-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/worker-1/config/request/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('remoted');
+                res.body.data.internal.remoted.should.have.properties(['request_timeout', 'pass_empty_keyfile',
+                'recv_timeout', 'request_rto_sec', 'request_rto_msec', 'response_timeout', 'sender_pool', 'recv_counter_flush',
+                'request_pool', 'comp_average_printout', 'shared_reload', 'merge_shared', 'rlimit_nofile',
+                'verify_msg_id', 'max_attempts']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // syscheck
+		it('Request-Syscheck-Syscheck', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/syscheck/syscheck")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['syscheck']);
+                res.body.data.syscheck.should.have.properties(['ignore', 'skip_nfs', 'directories',
+                'scan_on_start', 'disabled', 'frequency', 'whodata', 'nodiff']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Syscheck-Rootcheck', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/syscheck/rootcheck")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['rootcheck']);
+                res.body.data.rootcheck.should.have.properties(['check_unixaudit', 'check_sys', 'rootkit_trojans',
+                'skip_nfs', 'check_if', 'check_pids', 'check_dev', 'check_ports', 'disabled', 'rootkit_files',
+                // 'frequency', 'scanall', 'check_trojans', 'base_directory', 'check_files', 'system_audit']); // base directory value is empty, this cause an error
+                'frequency', 'scanall', 'check_trojans', 'check_files', 'system_audit']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Syscheck-Internal', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/syscheck/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['internal']);
+                res.body.data.internal.should.have.properties(['syscheck', 'rootcheck']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // wmodules
+		it('Request-Wmodules-Wmodules', function(done) {
+            request(common.url)
+            .get("/cluster/master/config/wmodules/wmodules")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['wmodules']);
+                //res.body.data.wmodules.should.have.properties(['open-scap', 'cis-cat',
+                //'osquery', 'syscollector', 'database', 'wazuh_download']);
+                res.body.data.wmodules[0].should.have.properties(['open-scap']);
+                res.body.data.wmodules[1].should.have.properties(['syscollector']);
+                res.body.data.wmodules[2].should.have.properties(['vulnerability-detector']);
+                res.body.data.wmodules[3].should.have.properties(['cis-cat']);
+                res.body.data.wmodules[4].should.have.properties(['database']);
+                res.body.data.wmodules[5].should.have.properties(['wazuh_download']);
+
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+
+    }); // GET/cluster/master/config/:component/:configuration
 
 }); // Cluster

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -2213,14 +2213,13 @@ describe('Cluster', function () {
 
                 res.body.should.have.properties(['error', 'data']);
                 res.body.data.should.have.properties(['wmodules']);
-                //res.body.data.wmodules.should.have.properties(['open-scap', 'cis-cat',
-                //'osquery', 'syscollector', 'database', 'wazuh_download']);
                 res.body.data.wmodules[0].should.have.properties(['open-scap']);
                 res.body.data.wmodules[1].should.have.properties(['syscollector']);
                 res.body.data.wmodules[2].should.have.properties(['vulnerability-detector']);
                 res.body.data.wmodules[3].should.have.properties(['cis-cat']);
-                res.body.data.wmodules[4].should.have.properties(['database']);
-                res.body.data.wmodules[5].should.have.properties(['wazuh_download']);
+                res.body.data.wmodules[4].should.have.properties(['sca']);
+                res.body.data.wmodules[5].should.have.properties(['database']);
+                res.body.data.wmodules[6].should.have.properties(['wazuh_download']);
 
 
                 res.body.error.should.equal(0);

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -41,7 +41,7 @@ describe('Manager', function() {
 
                 res.body.data.should.have.properties(['ossec-agentlessd', 'ossec-analysisd', 'ossec-authd', 'ossec-csyslogd', 'ossec-dbd', 'ossec-monitord',
                                                       'ossec-execd', 'ossec-integratord', 'ossec-logcollector', 'ossec-maild', 'ossec-remoted',
-                                                      'ossec-reportd', 'ossec-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd']);
+                                                      'ossec-reportd', 'ossec-syscheckd', 'wazuh-clusterd', 'wazuh-modulesd', 'wazuh-db']);
                 done();
             });
         });
@@ -1268,5 +1268,492 @@ describe('Manager', function() {
 
     });  // PUT/manager/restart
 
+    describe('GET/manager/config/:component/:configuration', function () {
+
+		// agentless
+		it('Request-Agentless-Agentless', function(done) {
+            request(common.url)
+            .get("/manager/config/agentless/agentless")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('agentless'); // returns an array
+                res.body.data.agentless[0].should.have.properties(['state', 'host',
+                'frequency', 'arguments', 'type', 'port']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // analysis
+		it('Request-Analysis-Global', function(done) {
+            request(common.url)
+            .get("/manager/config/analysis/global")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['global']);
+                res.body.data.global.should.have.properties(['email_notification', 'max_output_size',
+                'alerts_log', 'zeromq_output', 'host_information', 'jsonout_output', 'rotate_interval',
+                'rootkit_detection', 'integrity_checking', 'memory_size', 'logall', 'prelude_output',
+                'stats', 'white_list', 'logall_json']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Active-response', function(done) {
+            request(common.url)
+            .get("/manager/config/analysis/active_response")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                // res.body.data.should.have.properties(['active_response']); // empty list
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Alerts', function(done) {
+            request(common.url)
+            .get("/manager/config/analysis/alerts")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['alerts']);
+                res.body.data.alerts.should.have.properties(['email_alert_level', 'log_alert_level']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Command', function(done) {
+            request(common.url)
+            .get("/manager/config/analysis/command")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('command');
+                res.body.data.command[0].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[1].should.have.properties(['executable', 'timeout_allowed',
+                'name']);
+                res.body.data.command[2].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[3].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[4].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+                res.body.data.command[5].should.have.properties(['executable', 'timeout_allowed',
+                'name', 'expect']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Analysis-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/analysis/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties(['analysisd']);
+                res.body.data.internal.analysisd.should.have.properties(['label_cache_maxage',
+                'stats_percent_diff', 'show_hidden_labels', 'decoder_order_size',
+                'min_rotate_interval', 'stats_mindiff', 'log_fw', 'rlimit_nofile', 'fts_list_size',
+                'debug', 'fts_min_size_for_str', 'default_timeframe', 'stats_maxdiff']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // auth
+		it('Request-Auth-Auth', function(done) {
+            request(common.url)
+            .get("/manager/config/auth/auth")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('auth');
+                res.body.data.auth.should.have.properties(['purge', 'ssl_auto_negotiate', 'ciphers',
+                'force_insert', 'ssl_verify_host', 'limit_maxagents', 'force_time',
+                'ssl_manager_key', 'disabled', 'ssl_manager_cert', 'use_source_ip',
+                'use_password', 'port']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // com
+		it('Request-Com-Active-response', function(done) {
+            request(common.url)
+            .get("/manager/config/com/active-response")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['active-response']);
+                res.body.data['active-response'].should.have.properties(['disabled', 'ca_verification']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Com-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/com/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['internal']);
+                res.body.data.internal.should.have.properties(['execd']);
+                res.body.data.internal.execd.should.have.properties(['request_timeout', 'max_restart_lock']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // csyslog
+		it('Request-Csyslog-Csyslog', function(done) {
+            request(common.url)
+            .get("/manager/config/csyslog/csyslog")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['syslog_output']);
+                res.body.data['syslog_output'][0].should.have.properties(['format',
+                'level', 'use_fqdn', 'port', 'server']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // integrator
+		it('Request-Integrator-Integration', function(done) {
+            request(common.url)
+            .get("/manager/config/integrator/integration")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('integration');
+                res.body.data.integration[0].should.have.properties(['alert_format', 'hook_url',
+                'group', 'name', 'level']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // logcollector  // fails without any motive
+		it('Request-Logcollector-Localfile', function(done) {
+            request(common.url)
+            .get("/manager/config/logcollector/localfile")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('localfile');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Logcollector-Socket', function(done) {
+            request(common.url)
+            .get("/manager/config/logcollector/socket")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                // res.body.should.have.properties(['error', 'data']); // data property is empty
+                // res.body.data.should.have.properties(['socket']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Logcollector-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/logcollector/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('logcollector');
+				res.body.data.internal.logcollector.should.have.properties(['open_attempts', 'input_threads',
+                'vcheck_files', 'max_files', 'sock_fail_time', 'queue_size', 'max_lines', 'remote_commands',
+                'loop_timeout', 'debug', 'open_attempts']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // mail
+		it('Request-Mail-Global', function(done) {
+            request(common.url)
+            .get("/manager/config/mail/global")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('global');
+                res.body.data.global.should.have.properties(['email_maxperhour', 'email_to',
+                'email_from', 'smtp_server']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Mail-Alerts', function(done) {
+            request(common.url)
+            .get("/manager/config/mail/alerts")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                // res.body.should.have.properties(['error', 'data']); // data property is empty
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Mail-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/mail/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('mail');
+                res.body.data.internal.mail.should.have.properties(['strict_checking',
+                'grouping']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // monitor
+		it('Request-Monitor-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/monitor/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('monitord');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // request
+		it('Request-Request-Remote', function(done) {
+            request(common.url)
+            .get("/manager/config/request/remote")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('remote');
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Request-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/request/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties('internal');
+                res.body.data.internal.should.have.properties('remoted');
+                res.body.data.internal.remoted.should.have.properties(['request_timeout', 'pass_empty_keyfile',
+                'recv_timeout', 'request_rto_sec', 'request_rto_msec', 'response_timeout', 'sender_pool', 'recv_counter_flush',
+                'request_pool', 'comp_average_printout', 'shared_reload', 'merge_shared', 'rlimit_nofile',
+                'verify_msg_id', 'max_attempts']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // syscheck
+		it('Request-Syscheck-Syscheck', function(done) {
+            request(common.url)
+            .get("/manager/config/syscheck/syscheck")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['syscheck']);
+                res.body.data.syscheck.should.have.properties(['ignore', 'skip_nfs', 'directories',
+                'scan_on_start', 'disabled', 'frequency', 'whodata', 'nodiff']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Syscheck-Rootcheck', function(done) {
+            request(common.url)
+            .get("/manager/config/syscheck/rootcheck")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['rootcheck']);
+                res.body.data.rootcheck.should.have.properties(['check_unixaudit', 'check_sys', 'rootkit_trojans',
+                'skip_nfs', 'check_if', 'check_pids', 'check_dev', 'check_ports', 'disabled', 'rootkit_files',
+                // 'frequency', 'scanall', 'check_trojans', 'base_directory', 'check_files', 'system_audit']); // base directory value is empty, this cause an error
+                'frequency', 'scanall', 'check_trojans', 'check_files', 'system_audit']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        it('Request-Syscheck-Internal', function(done) {
+            request(common.url)
+            .get("/manager/config/syscheck/internal")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['internal']);
+                res.body.data.internal.should.have.properties(['syscheck', 'rootcheck']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+        // wmodules
+		it('Request-Wmodules-Wmodules', function(done) {
+            request(common.url)
+            .get("/manager/config/wmodules/wmodules")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['wmodules']);
+                //res.body.data.wmodules.should.have.properties(['open-scap', 'cis-cat',
+                //'osquery', 'syscollector', 'database', 'wazuh_download']);
+                res.body.data.wmodules[0].should.have.properties(['open-scap']);
+                res.body.data.wmodules[1].should.have.properties(['syscollector']);
+                res.body.data.wmodules[2].should.have.properties(['vulnerability-detector']);
+                res.body.data.wmodules[3].should.have.properties(['cis-cat']);
+                res.body.data.wmodules[4].should.have.properties(['database']);
+                res.body.data.wmodules[5].should.have.properties(['wazuh_download']);
+
+                res.body.error.should.equal(0);
+                done();
+            });
+        });
+
+
+    }); // GET/manager/config/:component/:configuration
 
 });  // Manager

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -1739,14 +1739,13 @@ describe('Manager', function() {
 
                 res.body.should.have.properties(['error', 'data']);
                 res.body.data.should.have.properties(['wmodules']);
-                //res.body.data.wmodules.should.have.properties(['open-scap', 'cis-cat',
-                //'osquery', 'syscollector', 'database', 'wazuh_download']);
                 res.body.data.wmodules[0].should.have.properties(['open-scap']);
                 res.body.data.wmodules[1].should.have.properties(['syscollector']);
                 res.body.data.wmodules[2].should.have.properties(['vulnerability-detector']);
                 res.body.data.wmodules[3].should.have.properties(['cis-cat']);
-                res.body.data.wmodules[4].should.have.properties(['database']);
-                res.body.data.wmodules[5].should.have.properties(['wazuh_download']);
+                res.body.data.wmodules[4].should.have.properties(['sca']);
+                res.body.data.wmodules[5].should.have.properties(['database']);
+                res.body.data.wmodules[6].should.have.properties(['wazuh_download']);
 
                 res.body.error.should.equal(0);
                 done();


### PR DESCRIPTION
Hello team,

This PR adds API support for https://github.com/wazuh/wazuh/issues/2988.

Mocha tests:
```javascript
# mocha test/test_cluster.js --grep component


  Cluster
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (314ms)
      ✓ Request-Analysis-Global (307ms)
      ✓ Request-Analysis-Active-response (337ms)
      ✓ Request-Analysis-Alerts (294ms)
      ✓ Request-Analysis-Command (287ms)
      ✓ Request-Analysis-Internal (297ms)
      ✓ Request-Auth-Auth (307ms)
      ✓ Request-Com-Active-response (295ms)
      ✓ Request-Com-Internal (280ms)
      ✓ Request-Csyslog-Csyslog (297ms)
      ✓ Request-Integrator-Integration (291ms)
      ✓ Request-Logcollector-Localfile (303ms)
      ✓ Request-Logcollector-Socket (289ms)
      ✓ Request-Logcollector-Internal (302ms)
      ✓ Request-Mail-Global (282ms)
      ✓ Request-Mail-Alerts (285ms)
      ✓ Request-Mail-Internal (283ms)
      ✓ Request-Monitor-Internal (292ms)
      ✓ Request-Request-Remote (282ms)
      ✓ Request-Request-Internal (296ms)
      ✓ Request-Syscheck-Syscheck (288ms)
      ✓ Request-Syscheck-Rootcheck (280ms)
      ✓ Request-Syscheck-Internal (285ms)
      ✓ Request-Wmodules-Wmodules (285ms)


  24 passing (7s)

# mocha test/test_manager.js --grep component


  Manager
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (311ms)
      ✓ Request-Analysis-Global (330ms)
      ✓ Request-Analysis-Active-response (428ms)
      ✓ Request-Analysis-Alerts (324ms)
      ✓ Request-Analysis-Command (311ms)
      ✓ Request-Analysis-Internal (563ms)
      ✓ Request-Auth-Auth (319ms)
      ✓ Request-Com-Active-response (305ms)
      ✓ Request-Com-Internal (312ms)
      ✓ Request-Csyslog-Csyslog (306ms)
      ✓ Request-Integrator-Integration (308ms)
      ✓ Request-Logcollector-Localfile (359ms)
      ✓ Request-Logcollector-Socket (297ms)
      ✓ Request-Logcollector-Internal (289ms)
      ✓ Request-Mail-Global (286ms)
      ✓ Request-Mail-Alerts (293ms)
      ✓ Request-Mail-Internal (293ms)
      ✓ Request-Monitor-Internal (283ms)
      ✓ Request-Request-Remote (292ms)
      ✓ Request-Request-Internal (299ms)
      ✓ Request-Syscheck-Syscheck (280ms)
      ✓ Request-Syscheck-Rootcheck (285ms)
      ✓ Request-Syscheck-Internal (306ms)
      ✓ Request-Wmodules-Wmodules (288ms)


  24 passing (8s)

# mocha test/test_agents.js --grep component


  Agents
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (331ms)
      ✓ Request-Agent-Buffer (445ms)
      ✓ Request-Agent-Labels (631ms)
      ✓ Request-Agent-Internal (458ms)
      ✓ Request-Agentless-Agentless (365ms)
      ✓ Request-Analysis-Global (313ms)
      ✓ Request-Analysis-Active-response (414ms)
      ✓ Request-Analysis-Alerts (317ms)
      ✓ Request-Analysis-Command (307ms)
      ✓ Request-Analysis-Internal (351ms)
      ✓ Request-Auth-Auth (315ms)
      ✓ Request-Com-Active-response (311ms)
      ✓ Request-Com-Internal (320ms)
      ✓ Request-Csyslog-Csyslog (317ms)
      ✓ Request-Integrator-Integration (316ms)
      ✓ Request-Logcollector-Localfile (356ms)
      ✓ Request-Logcollector-Socket (394ms)
      ✓ Request-Logcollector-Internal (371ms)
      ✓ Request-Mail-Global (371ms)
      ✓ Request-Mail-Alerts (355ms)
      ✓ Request-Mail-Internal (402ms)
      ✓ Request-Monitor-Internal (381ms)
      ✓ Request-Request-Remote (382ms)
      ✓ Request-Request-Internal (330ms)
      ✓ Request-Syscheck-Syscheck (413ms)
      ✓ Request-Syscheck-Rootcheck (354ms)
      ✓ Request-Syscheck-Internal (314ms)
      ✓ Request-Wmodules-Wmodules (354ms)


  28 passing (10s)
```

Best regards,
Marta