### PR TITLE
 Fix unhandled exception when posting files with an invalid content type

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -562,6 +562,7 @@ router.post('/:node_id/files', function(req, res) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
+        return;
     }
 
     if (req.headers['content-type'] == 'application/octet-stream' || req.headers['content-type'] == 'application/xml') {
@@ -577,6 +578,7 @@ router.post('/:node_id/files', function(req, res) {
         }
     } else {
         res_h.bad_request(req, res, 804, req.headers['content-type']);
+        return;
     }
 
 

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -564,9 +564,10 @@ router.post('/:node_id/files', function(req, res) {
         res_h.bad_request(req, res, 706);
     }
 
-    if (req.headers['content-type'] == 'application/octet-stream') {
-        // check cdb list
-        if (!filter.check_cdb_list(req.body.toString('utf8'), req, res)) return;
+    if (req.headers['content-type'] == 'application/octet-stream' || req.headers['content-type'] == 'application/xml') {
+        if ((req.headers['content-type'] == 'application/octet-stream' && !filter.check_cdb_list(req.body.toString('utf8'), req, res)) ||
+            (req.headers['content-type'] == 'application/xml' && !filter.check_xml(req.body, req, res)))
+            return;
 
         try {
             data_request['arguments']['tmp_file'] = require('../helpers/files').tmp_file_creator(req.body);
@@ -574,21 +575,10 @@ router.post('/:node_id/files', function(req, res) {
             res_h.bad_request(req, res, 702, err);
             return;
         }
-
-    } else if (req.headers['content-type'] == 'application/xml') {
-
-        if (!filter.check_xml(req.body, req, res)) return;
-
-        try {
-            data_request['arguments']['tmp_file'] = require('../helpers/files').tmp_file_creator(req.body);
-        } catch(err) {
-            res_h.bad_request(req, res, 702, err);
-            return;
-        }
-
     } else {
-        res_h.bad_request(req, res, 704, err);
+        res_h.bad_request(req, res, 804, req.headers['content-type']);
     }
+
 
     data_request['arguments']['node_id'] = req.params.node_id;
     data_request['arguments']['path'] = req.query.path;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -411,6 +411,7 @@ router.post('/files', function(req, res) {
         if (!filter.check_path(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
+        return;
     }
 
     if (req.headers['content-type'] == 'application/octet-stream' || req.headers['content-type'] == 'application/xml') {
@@ -426,6 +427,7 @@ router.post('/files', function(req, res) {
         }
     } else {
         res_h.bad_request(req, res, 804, req.headers['content-type']);
+        return;
     }
 
     data_request['arguments']['path'] = req.query.path;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -413,9 +413,10 @@ router.post('/files', function(req, res) {
         res_h.bad_request(req, res, 706);
     }
 
-    if (req.headers['content-type'] == 'application/octet-stream') {
-        // check cdb list
-        if (!filter.check_cdb_list(req.body.toString('utf8'), req, res)) return;
+    if (req.headers['content-type'] == 'application/octet-stream' || req.headers['content-type'] == 'application/xml') {
+        if ((req.headers['content-type'] == 'application/octet-stream' && !filter.check_cdb_list(req.body.toString('utf8'), req, res)) ||
+            (req.headers['content-type'] == 'application/xml' && !filter.check_xml(req.body, req, res)))
+            return;
 
         try {
             data_request['arguments']['tmp_file'] = require('../helpers/files').tmp_file_creator(req.body);
@@ -423,20 +424,8 @@ router.post('/files', function(req, res) {
             res_h.bad_request(req, res, 702, err);
             return;
         }
-
-    } else if (req.headers['content-type'] == 'application/xml') {
-
-        if (!filter.check_xml(req.body, req, res)) return;
-
-        try {
-            data_request['arguments']['tmp_file'] = require('../helpers/files').tmp_file_creator(req.body);
-        } catch(err) {
-            res_h.bad_request(req, res, 702, err);
-            return;
-        }
-
     } else {
-        res_h.bad_request(req, res, 704, err);
+        res_h.bad_request(req, res, 804, req.headers['content-type']);
     }
 
     data_request['arguments']['path'] = req.query.path;

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -988,6 +988,26 @@ describe('Cluster', function () {
               });
         });
 
+        it('Upload a file with a wrong content type', function(done) {
+            request(common.url)
+            .post("/cluster/master/files")
+            .set("Content-Type", "application/x-www-form-urlencoded")
+            .send("test&%-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(804);
+                res.body.message.should.be.an.string;
+
+                done();
+              });
+        });
+
     });  // POST/cluster/:node_id/files
 
 

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -900,6 +900,25 @@ describe('Manager', function() {
               });
         });
 
+        it('Upload a file with a wrong content type', function(done) {
+            request(common.url)
+            .post("/manager/files?path=" + path_lists)
+            .set("Content-Type", "application/x-www-form-urlencoded")
+            .send("test-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err, res) {
+                if (err) throw err;
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(804);
+                res.body.message.should.be.an.string;
+
+                done();
+              });
+        });
+
     });  // POST/manager/files
 
     describe('GET/manager/files', function() {


### PR DESCRIPTION
Hello team,

This PR fixes #363 in df18a3f787dedf78a1a8269ea8f4fc941206c138. 

Running our mocha tests I realized there was an additional bug. The test to do a request omitting `path` argument was working properly but caused the following errors in the `api.log` file:
```
WazuhAPI 2019-04-05 11:19:27 foo: ::ffff:127.0.0.1 POST /manager/files
WazuhAPI 2019-04-05 11:19:27 foo: [::ffff:127.0.0.1] POST /manager/files - 400 - error: '706'.
WazuhAPI 2019-04-05 11:19:27 foo: Response: {"error":706,"message":"'path' parameter is mandatory"} HTTP Status: 400
WazuhAPI 2019-04-05 11:19:27 foo: CMD - Command: /var/ossec/framework/python/bin/python3 args:/var/ossec/api/models/wazuh-api.py stdin:{"function":"POST/manager/files","arguments":{"tmp_file":"tmp/api_group_conf_1554463167_312","content_type":"application/octet-stream","wait_for_complete":false},"ossec_path":"/var/ossec"}
WazuhAPI 2019-04-05 11:19:27 foo: CMD - Exit code: 0
WazuhAPI 2019-04-05 11:19:27 foo: CMD - STDOUT:
---
{"message": "upload_file() missing 1 required positional argument: 'path'", "error": 1000}

---
WazuhAPI 2019-04-05 11:19:27 foo: CMD - STDOUT: 91 bytes
WazuhAPI 2019-04-05 11:19:27 foo: upload_file() missing 1 required positional argument: 'path'
```

That means, despite the API was returning an error, the python backend was still being called. I fixed this bug in 152472558b9207839ad689b7918bc526e87d301e.

Mocha tests:
```javascript
# mocha test/test_manager.js --grep POST/manager/files
  Manager
    POST/manager/files
      ✓ Upload ossec.conf (323ms)
      ✓ Upload ossec.conf (overwrite=false) (303ms)
      ✓ Upload rules (new rule) (334ms)
      ✓ Upload rules (overwrite=true) (295ms)
      ✓ Upload rules (overwrite=false) (286ms)
      ✓ Upload decoder (overwrite=true) (289ms)
      ✓ Upload decoder (without overwrite parameter) (288ms)
      ✓ Upload list (overwrite=true) (285ms)
      ✓ Upload list (without overwrite parameter) (298ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
  14 passing (3s)
  
  # mocha test/test_cluster.js --grep POST/cluster/:node_id/files
  Cluster
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (298ms)
      ✓ Upload ossec.conf (worker) (343ms)
      ✓ Upload new rules (332ms)
      ✓ Upload rules (overwrite=true) (296ms)
      ✓ Upload rules (overwrite=false) (291ms)
      ✓ Upload new decoder (303ms)
      ✓ Upload decoder (overwrite=true) (308ms)
      ✓ Upload decoder (without overwrite parameter) (303ms)
      ✓ Upload new list (281ms)
      ✓ Upload list (overwrite=true) (275ms)
      ✓ Upload list (overwrite=false) (280ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (276ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (279ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (272ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
  21 passing (5s)
```

Best regards,
Marta