### PR TITLE
Get rules and decoders from ruleset directory

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -514,7 +514,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, get_request=true)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -335,7 +335,7 @@ router.get('/files', cache(), function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, get_request=true)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -69,11 +69,13 @@ exports.check_path = function(path, req, res, get_request=false) {
         if (!re_get.test(path)) {
             res_h.bad_request(req, res, 704);
             return false
+        }
     } else {
         var re_post = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
         if (!re_post.test(path)) {
             res_h.bad_request(req, res, 704);
             return false
+        }
     }
 
     return true

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -57,20 +57,23 @@ exports.check_xml = function(xml_string, req, res) {
     };
 }
 
-exports.check_path = function(path, req, res) {
+exports.check_path = function(path, req, res, get_request=false) {
     if (path.includes('./') || path.includes('../')) {
         res_h.bad_request(req, res, 704);
         return false
     }
 
-    if (path == 'etc/ossec.conf') {
-        return true
-    }
-
-    re = new RegExp(/((^etc\/rules\/|^etc\/decoders\/)[\w\-\/]+\.{1}xml|(^etc\/lists\/)[\w\-\.\/]+)/)
-    if (!re.test(path)) {
-        res_h.bad_request(req, res, 704);
-        return false
+    // allow global rules and decoders for GET requests
+    if (get_request) {
+        var re_get = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+        if (!re_get.test(path)) {
+            res_h.bad_request(req, res, 704);
+            return false
+    } else {
+        var re_post = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+        if (!re_post.test(path)) {
+            res_h.bad_request(req, res, 704);
+            return false
     }
 
     return true

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1051,7 +1051,7 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Request rules', function (done) {
+        it('Request rules (local)', function (done) {
             request(common.url)
                 .get("/cluster/master/files?path=" + path_rules)
                 .auth(common.credentials.user, common.credentials.password)
@@ -1069,9 +1069,45 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Request decoders', function(done) {
+        it('Request rules (global)', function (done) {
+            request(common.url)
+                .get("/cluster/master/files?path=ruleset/rules/0095-sshd_rules.xml")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.be.an.string;
+
+                    done();
+                });
+        });
+
+        it('Request decoders (local)', function(done) {
             request(common.url)
             .get("/cluster/master/files?path=" + path_decoders)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        it('Request decoders (global)', function(done) {
+            request(common.url)
+            .get("/cluster/master/files?path=ruleset/decoders/0025-apache_decoders.xml")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -990,7 +990,7 @@ describe('Cluster', function () {
 
         it('Upload a file with a wrong content type', function(done) {
             request(common.url)
-            .post("/cluster/master/files")
+            .post("/cluster/master/files?path=etc/lists/new-list")
             .set("Content-Type", "application/x-www-form-urlencoded")
             .send("test&%-wazuh-w:write\ntest-wazuh-r:read\ntest-wazuh-a:attribute\ntest-wazuh-x:execute\ntest-wazuh-c:command\n")
             .auth(common.credentials.user, common.credentials.password)

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -432,8 +432,8 @@ describe('Cluster', function () {
                 .expect(200)
                 .end(function (err, res) {
                     if (err) return done(err);
-                    expected_name_master = res.body.data.items[1].name;
-                    expected_name_worker = res.body.data.items[0].name;
+                    expected_name_master = res.body.data.items[0].name;
+                    expected_name_worker = res.body.data.items[1].name;
                     done();
                 });
         });

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -1301,28 +1301,6 @@ describe('Manager', function() {
 
     });  // GET/manager/configuration/validation (KO)
 
-    describe('PUT/manager/restart', function() {
-
-        it('Request', function(done) {
-            request(common.url)
-            .put("/manager/restart")
-            .auth(common.credentials.user, common.credentials.password)
-            .expect("Content-type",/json/)
-            .expect(200)
-            .end(function(err,res){
-                if (err) return done(err);
-
-                res.body.should.have.properties(['error', 'data']);
-
-                res.body.error.should.equal(0);
-                res.body.data.should.be.an.string;
-
-                done();
-            });
-        });
-
-    });  // PUT/manager/restart
-
     describe('GET/manager/config/:component/:configuration', function () {
 
 		// agentless
@@ -1809,5 +1787,27 @@ describe('Manager', function() {
 
 
     }); // GET/manager/config/:component/:configuration
+
+    describe('PUT/manager/restart', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .put("/manager/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+    });  // PUT/manager/restart
 
 });  // Manager

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -980,7 +980,7 @@ describe('Manager', function() {
 
         it('Request decoders (local)', function(done) {
             request(common.url)
-            .get("/manager/files?path=/ruleset/decoders/0005-wazuh_decoders.xml" + path_decoders)
+            .get("/manager/files?path=" + path_decoders)
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -998,7 +998,7 @@ describe('Manager', function() {
 
         it('Request decoders (global)', function(done) {
             request(common.url)
-            .get("/manager/files?path=")
+            .get("/manager/files?path=ruleset/decoders/0005-wazuh_decoders.xml")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)

--- a/test/test_manager.js
+++ b/test/test_manager.js
@@ -942,7 +942,7 @@ describe('Manager', function() {
                 });
         });
 
-        it('Request rules', function(done) {
+        it('Request rules (local)', function(done) {
             request(common.url)
             .get("/manager/files?path=" + path_rules)
             .auth(common.credentials.user, common.credentials.password)
@@ -960,9 +960,45 @@ describe('Manager', function() {
             });
         });
 
-        it('Request decoders', function(done) {
+        it('Request rules (global)', function(done) {
             request(common.url)
-            .get("/manager/files?path=" + path_decoders)
+            .get("/manager/files?path=ruleset/rules/0350-amazon_rules.xml")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        it('Request decoders (local)', function(done) {
+            request(common.url)
+            .get("/manager/files?path=/ruleset/decoders/0005-wazuh_decoders.xml" + path_decoders)
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.an.string;
+
+                done();
+            });
+        });
+
+        it('Request decoders (global)', function(done) {
+            request(common.url)
+            .get("/manager/files?path=")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)


### PR DESCRIPTION
Hi team,

This PR closes #369. Now it is possible getting rules and decoders from `ruleset`directory:

```bash
# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=ruleset/rules/0016-wazuh_rules.xml&validation=true&pretty"
{
   "error": 0,
   "data": "<!--\n  -  Wazuh rules\n  -  Created by Wazuh, Inc.\n  -  Copyright (C) 2015-2019, Wazuh Inc.\n  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.\n-->\n\n<group name=\"wazuh,\">\n  <rule id=\"200\" level=\"0\">\n    <decoded_as>wazuh</decoded_as>\n    <description>Grouping of wazuh rules.</description>\n  </rule>\n\n  <!-- Agent buffer rules -->\n  <rule id=\"201\" level=\"0\">\n    <if_sid>200</if_sid>\n    <match>^wazuh: Agent buffer: </match>\n    <description>Agent event queue rule</description>\n    <group>agent_flooding,</group>\n  </rule>\n\n  <rule id=\"202\" level=\"7\">\n    <if_sid>201</if_sid>\n    <field name=\"level\">%</field>\n    <description>Agent event queue is $(level) full.</description>\n    <group>agent_flooding,gdpr_IV_35.7.d,</group>\n  </rule>\n\n  <rule id=\"203\" level=\"9\">\n    <if_sid>201</if_sid>\n    <field name=\"level\">full</field>\n    <description>Agent event queue is full. Events may be lost.</description>\n    <group>agent_flooding,gdpr_IV_35.7.d,</group>\n  </rule>\n\n  <rule id=\"204\" level=\"12\">\n    <if_sid>201</if_sid>\n    <field name=\"level\">flooded</field>\n    <description>Agent event queue is flooded. Check the agent configuration.</description>\n    <group>agent_flooding,gdpr_IV_35.7.d,</group>\n  </rule>\n\n  <rule id=\"205\" level=\"3\">\n    <if_sid>201</if_sid>\n    <field name=\"level\">normal</field>\n    <description>Agent event queue is back to normal load.</description>\n    <group>agent_flooding,</group>\n  </rule>\n\n\n  <!-- Remote upgrading rules -->\n  <!--\n    wazuh: Upgrade procedure on agent 001 (TestAgent): started. Current version: v3.0.0\n    wazuh: Upgrade procedure on agent 001 (TestAgent): aborted: Cannot execute installer\n    wazuh: Upgrade procedure on agent 001 (TestAgent): succeeded. New version: v3.1.0\n    wazuh: Upgrade procedure on agent 001 (TestAgent): failed: Restored to previous version\n    wazuh: Upgrade procedure on agent 001 (TestAgent): lost: Maximum attempts exceeded\n    wazuh: Custom installation on agent 001 (TestAgent): started.\n    wazuh: Custom installation on agent 001 (TestAgent): aborted: Could not verify signature\n  -->\n  <rule id=\"210\" level=\"0\">\n    <if_sid>200</if_sid>\n    <match>Upgrade procedure</match>\n    <description>Remote upgrade alert</description>\n    <group>upgrade,</group>\n  </rule>\n\n  <rule id=\"211\" level=\"0\">\n    <if_sid>200</if_sid>\n    <match>Custom installation</match>\n    <description>Remote installation alert</description>\n    <group>upgrade,</group>\n  </rule>\n\n  <rule id=\"212\" level=\"3\">\n    <if_sid>210</if_sid>\n    <status>started</status>\n    <description>Remote upgrade started.</description>\n    <group>upgrade,</group>\n  </rule>\n\n  <rule id=\"213\" level=\"7\">\n    <if_sid>210</if_sid>\n    <status>aborted</status>\n    <description>Remote upgrade could not be launched. Error: $(error).</description>\n    <group>upgrade,upgrade_failure,</group>\n  </rule>\n\n  <rule id=\"214\" level=\"3\">\n    <if_sid>210</if_sid>\n    <status>succeeded</status>\n    <description>Remote upgrade finished successfully.</description>\n    <group>upgrade,upgrade_success,</group>\n  </rule>\n\n  <rule id=\"215\" level=\"6\">\n    <if_sid>210</if_sid>\n    <status>failed</status>\n    <description>Remote upgrade failed. Agent restored to previous version.</description>\n    <group>upgrade,upgrade_failure,</group>\n  </rule>\n\n  <rule id=\"216\" level=\"7\">\n    <if_sid>210</if_sid>\n    <status>lost</status>\n    <description>Remote upgrade failed. Agent disconnected.</description>\n    <group>upgrade,upgrade_failure,</group>\n  </rule>\n\n  <rule id=\"217\" level=\"3\">\n    <if_sid>211</if_sid>\n    <status>started</status>\n    <description>Custom installation started.</description>\n    <group>upgrade,</group>\n  </rule>\n\n  <rule id=\"218\" level=\"7\">\n    <if_sid>211</if_sid>\n    <status>aborted</status>\n    <description>Custom installation could not be launched. Error: $(error).</description>\n    <group>upgrade,upgrade_failure,</group>\n  </rule>\n\n  <rule id=\"220\" level=\"7\">\n    <if_sid>200</if_sid>\n    <match>^wazuh: Invalid remote configuration: </match>\n    <description>The agent could not restart due to a $(module) failure in the remote configuration</description>\n    <group>agent_restarting,configuration_failure,</group>\n  </rule>\n\n  <!-- Ignore syscollector events -->\n  <rule id=\"221\" level=\"0\">\n    <category>ossec</category>\n    <decoded_as>syscollector</decoded_as>\n    <description>Syscollector event.</description>\n  </rule>\n\n  <rule id=\"222\" level=\"7\">\n    <if_sid>200</if_sid>\n    <match>^wazuh: Could not unmerge shared file.</match>\n    <description>The agent could not restart due to a error while unmerging files.</description>\n    <group>agent_restarting,configuration_failure,</group>\n  </rule>\n\n</group>\n"
}
```

```bash
# curl -u foo:bar -X GET "http://127.0.0.1:55000/manager/files?path=ruleset/decoders/0005-wazuh_decoders.xml&validation=true&pretty"
{
   "error": 0,
   "data": "<!--\n  -  Wazuh decoders\n  -  Created by Wazuh, Inc.\n  -  Copyright (C) 2015-2019, Wazuh Inc.\n  -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.\n-->\n\n<decoder name=\"wazuh\">\n  <prematch>^wazuh: </prematch>\n</decoder>\n\n<decoder name=\"agent-buffer\">\n  <parent>wazuh</parent>\n  <prematch offset=\"after_parent\">^Agent buffer:</prematch>\n  <regex offset=\"after_prematch\">^ '(\\S+)'.</regex>\n  <order>level</order>\n</decoder>\n\n<decoder name=\"agent-upgrade\">\n  <parent>wazuh</parent>\n  <prematch offset=\"after_parent\">^Upgrade procedure |^Custom installation </prematch>\n  <regex offset=\"after_prematch\">on agent (\\d\\d\\d)\\s\\((\\S+)\\):\\s(\\w+)</regex>\n  <order>agent.id, agent.name, status</order>\n</decoder>\n\n<decoder name=\"agent-upgrade\">\n  <parent>wazuh</parent>\n  <regex>aborted:\\s(\\.+)$|failed:\\s(\\.+)$|lost:\\s(\\.+)$</regex>\n  <order>error</order>\n</decoder>\n\n<decoder name=\"agent-upgrade\">\n  <parent>wazuh</parent>\n  <regex>started.\\sCurrent\\sversion:\\sWazuh\\s(\\.+)$</regex>\n  <order>agent.cur_version</order>\n</decoder>\n\n<decoder name=\"agent-upgrade\">\n  <parent>wazuh</parent>\n  <regex>succeeded.\\sNew\\sversion:\\sWazuh\\s(\\.+)$</regex>\n  <order>agent.new_version</order>\n</decoder>\n\n<decoder name=\"agent-restart\">\n  <parent>wazuh</parent>\n  <prematch offset=\"after_parent\">^Invalid remote configuration:</prematch>\n  <regex offset=\"after_prematch\">^ '(\\S+)'.</regex>\n  <order>module</order>\n</decoder>\n"
}
```

## Tests performed

#### Mocha test

```javascript
# mocha test/test_manager.js --timeout=10000


  Manager
    GET/manager/status
      ✓ Request (677ms)
    GET/manager/info
      ✓ Request (259ms)
    GET/manager/configuration
      ✓ Request (248ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (385ms)
      ✓ Errors: Invalid Section (202ms)
      ✓ Filters: Section - field (229ms)
      ✓ Errors: Invalid field (198ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (249ms)
      ✓ Filters: date (255ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (224ms)
    GET/manager/stats/weekly
      ✓ Request (234ms)
    GET/manager/stats/analysisd
      ✓ Request (221ms)
    GET/manager/stats/remoted
      ✓ Request (219ms)
    GET/manager/logs
      ✓ Request (238ms)
      ✓ Pagination (222ms)
      ✓ Retrieve all elements with limit=0 (224ms)
      ✓ Sort (245ms)
      ✓ SortField (233ms)
      ✓ Search (244ms)
      ✓ Filters: type_log (204ms)
      ✓ Filters: category (208ms)
      ✓ Filters: type_log and category (211ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (224ms)
    POST/manager/files
      ✓ Upload ossec.conf (217ms)
      ✓ Upload ossec.conf (overwrite=false) (227ms)
      ✓ Upload rules (new rule) (230ms)
      ✓ Upload rules (overwrite=true) (198ms)
      ✓ Upload rules (overwrite=false) (203ms)
      ✓ Upload decoder (overwrite=true) (208ms)
      ✓ Upload decoder (without overwrite parameter) (201ms)
      ✓ Upload list (overwrite=true) (204ms)
      ✓ Upload list (without overwrite parameter) (238ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (215ms)
      ✓ Request rules (local) (252ms)
      ✓ Request rules (global) (215ms)
      ✓ Request decoders (local) (231ms)
      ✓ Request decoders (global) (234ms)
      ✓ Request lists (213ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (217ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (405ms)
    DELETE/manager/files
      ✓ Delete rules (216ms)
      ✓ Delete decoders (217ms)
      ✓ Delete CDB list (236ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1280ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (224ms)
    PUT/manager/restart
      ✓ Request (198ms)
```

```javascript
# mocha test/test_cluster.js --timeout=10000


  Cluster
    GET/cluster/nodes
      ✓ Request (937ms)
      ✓ Pagination (227ms)
      ✓ Retrieve all elements with limit=0 (207ms)
      ✓ Sort (234ms)
      ✓ Search (213ms)
      ✓ Filters: type (225ms)
      ✓ Filters: invalid type (217ms)
      ✓ Select (222ms)
      ✓ Select 2 (232ms)
      ✓ Wrong select (217ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (187ms)
      ✓ Unexisting node stats (214ms)
      ✓ Analysisd stats (233ms)
      ✓ Remoted stats (224ms)
    GET/cluster/nodes/:node_name
      ✓ Request (188ms)
      ✓ Request wrong name (219ms)
    GET/cluster/status
      ✓ Request (206ms)
    GET/cluster/config
      ✓ Request (206ms)
    GET/cluster/healthcheck
      ✓ Request (189ms)
      ✓ Filter: node name (209ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (206ms)
      ✓ Upload ossec.conf (worker) (262ms)
      ✓ Upload new rules (214ms)
      ✓ Upload rules (overwrite=true) (198ms)
      ✓ Upload rules (overwrite=false) (205ms)
      ✓ Upload new decoder (203ms)
      ✓ Upload decoder (overwrite=true) (202ms)
      ✓ Upload decoder (without overwrite parameter) (264ms)
      ✓ Upload new list (315ms)
      ✓ Upload list (overwrite=true) (249ms)
      ✓ Upload list (overwrite=false) (237ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (236ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (247ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (226ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (247ms)
      ✓ Request ossec.conf (worker) (225ms)
      ✓ Request rules (local) (228ms)
      ✓ Request rules (global) (310ms)
      ✓ Request decoders (local) (234ms)
      ✓ Request decoders (global) (311ms)
      ✓ Request lists (373ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (267ms)
      ✓ Request file from unexisting node (447ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (636ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (1259ms)
      ✓ Request validation (worker) (1759ms)
      ✓ Request validation (all nodes) (940ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (198ms)
      ✓ Request validation (worker) (1048ms)
      ✓ Request validation (all nodes) (891ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (986ms)
      ✓ Request validation (worker) (358ms)
      ✓ Request validation (all nodes) (911ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (240ms)
      ✓ Request validation (worker)
      ✓ Request validation (all nodes) (255ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (208ms)
      ✓ Delete decoders (master) (229ms)
      ✓ Delete CDB list (master) (212ms)
      ✓ Delete file with empty path
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (547ms)
      ✓ Request (master) (377ms)
```

Best regards,

Demetrio.