### PR TITLE
Restore compatibility with NodeJS 4 version or lower

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -513,8 +513,9 @@ router.get('/:node_id/files', cache(), function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = false;
     if (req.query.path) {
-        if (!filter.check_path_get(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }
@@ -558,8 +559,9 @@ router.post('/:node_id/files', function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = true;
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;
@@ -620,8 +622,9 @@ router.delete('/:node_id/files', cache(), function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = true;
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -559,7 +559,7 @@ router.post('/:node_id/files', function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path_post(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -514,7 +514,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res, get_request=true)) return;
+        if (!filter.check_path_get(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }
@@ -559,7 +559,7 @@ router.post('/:node_id/files', function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path_post(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -335,7 +335,7 @@ router.get('/files', cache(), function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path_get(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }
@@ -408,7 +408,7 @@ router.post('/files', function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path_post(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -335,7 +335,7 @@ router.get('/files', cache(), function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res, get_request=true)) return;
+        if (!filter.check_path(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }
@@ -408,7 +408,7 @@ router.post('/files', function(req, res) {
 
     // check path parameter
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path_post(req.query.path, req, res)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -337,6 +337,7 @@ router.get('/files', cache(), function(req, res) {
     var local_paths = false;
     if (req.query.path) {
         if (!filter.check_path(req.query.path, req, res, local_paths)) return;
+    } else {
         res_h.bad_request(req, res, 706);
     }
 

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -334,9 +334,9 @@ router.get('/files', cache(), function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = false;
     if (req.query.path) {
-        if (!filter.check_path_get(req.query.path, req, res)) return;
-    } else {
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
         res_h.bad_request(req, res, 706);
     }
 
@@ -371,8 +371,9 @@ router.delete('/files', cache(), function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = true;
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
     } else {
         res_h.bad_request(req, res, 706);
     }
@@ -407,8 +408,9 @@ router.post('/files', function(req, res) {
         return;
 
     // check path parameter
+    var local_paths = true;
     if (req.query.path) {
-        if (!filter.check_path(req.query.path, req, res)) return;
+        if (!filter.check_path(req.query.path, req, res, local_paths)) return;
     } else {
         res_h.bad_request(req, res, 706);
         return;

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -57,25 +57,32 @@ exports.check_xml = function(xml_string, req, res) {
     };
 }
 
-exports.check_path = function(path, req, res, get_request=false) {
+exports.check_path = function(path, req, res) {
     if (path.includes('./') || path.includes('../')) {
         res_h.bad_request(req, res, 704);
         return false
     }
 
-    // allow global rules and decoders for GET requests
-    if (get_request) {
-        var re_get = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
-        if (!re_get.test(path)) {
-            res_h.bad_request(req, res, 704);
-            return false
-        }
-    } else {
-        var re_post = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
-        if (!re_post.test(path)) {
-            res_h.bad_request(req, res, 704);
-            return false
-        }
+    // allow global rules and decoders for GET and POST requests
+    var re = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+    if (!re.test(path)) {
+        res_h.bad_request(req, res, 704);
+        return false
+    }
+
+    return true
+}
+
+exports.check_path_post = function(path, req, res) {
+    if (path.includes('./') || path.includes('../')) {
+        res_h.bad_request(req, res, 704);
+        return false
+    }
+
+    var re_post = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+    if (!re_post.test(path)) {
+        res_h.bad_request(req, res, 704);
+        return false
     }
 
     return true

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -57,32 +57,25 @@ exports.check_xml = function(xml_string, req, res) {
     };
 }
 
-exports.check_path_get = function(path, req, res) {
+exports.check_path = function(path, req, res, local_paths) {
     if (path.includes('./') || path.includes('../')) {
         res_h.bad_request(req, res, 704);
         return false
     }
 
     // allow global rules and decoders for GET requests
-    var re = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
-    if (!re.test(path)) {
-        res_h.bad_request(req, res, 704);
-        return false
-    }
-
-    return true
-}
-
-exports.check_path = function(path, req, res) {
-    if (path.includes('./') || path.includes('../')) {
-        res_h.bad_request(req, res, 704);
-        return false
-    }
-
-    var re_post = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
-    if (!re_post.test(path)) {
-        res_h.bad_request(req, res, 704);
-        return false
+    if (local_paths) {
+        var re_local = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+        if (!re_local.test(path)) {
+            res_h.bad_request(req, res, 704);
+            return false
+        }
+    } else {
+        var re_global = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
+        if (!re_global.test(path)) {
+            res_h.bad_request(req, res, 704);
+            return false
+        }
     }
 
     return true

--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -57,13 +57,13 @@ exports.check_xml = function(xml_string, req, res) {
     };
 }
 
-exports.check_path = function(path, req, res) {
+exports.check_path_get = function(path, req, res) {
     if (path.includes('./') || path.includes('../')) {
         res_h.bad_request(req, res, 704);
         return false
     }
 
-    // allow global rules and decoders for GET and POST requests
+    // allow global rules and decoders for GET requests
     var re = new RegExp(/^((etc\/ossec.conf)|(etc\/rules\/|etc\/decoders\/|ruleset\/rules\/|ruleset\/decoders\/)[\w\-\/]+\.{1}xml|(etc\/lists\/)[\w\-\.\/]+)$/)
     if (!re.test(path)) {
         res_h.bad_request(req, res, 704);
@@ -73,7 +73,7 @@ exports.check_path = function(path, req, res) {
     return true
 }
 
-exports.check_path_post = function(path, req, res) {
+exports.check_path = function(path, req, res) {
     if (path.includes('./') || path.includes('../')) {
         res_h.bad_request(req, res, 704);
         return false


### PR DESCRIPTION
Hi team,

This PR closes #377. I removed the lines which was using parameters with default values for restoring `NodeJS 4` compatibility.

#### Mocha tests

##### Manager

```javascript
# mocha test/test_manager.js --timeout=10000


  Manager
    GET/manager/status
      ✓ Request (1738ms)
    GET/manager/info
      ✓ Request (503ms)
    GET/manager/configuration
      ✓ Request (507ms)
      ✓ Filters: Missing field section (56ms)
      ✓ Filters: Section (464ms)
      ✓ Errors: Invalid Section (415ms)
      ✓ Filters: Section - field (473ms)
      ✓ Errors: Invalid field (419ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      ✓ Request (450ms)
      ✓ Filters: date (400ms)
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (466ms)
    GET/manager/stats/weekly
      ✓ Request (663ms)
    GET/manager/stats/analysisd
      ✓ Request (626ms)
    GET/manager/stats/remoted
      ✓ Request (625ms)
    GET/manager/logs
      ✓ Request (677ms)
      ✓ Pagination (659ms)
      ✓ Retrieve all elements with limit=0 (746ms)
      ✓ Sort (601ms)
      ✓ SortField (753ms)
      ✓ Search (660ms)
      ✓ Filters: type_log (867ms)
      ✓ Filters: category (706ms)
      ✓ Filters: type_log and category (680ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (762ms)
    POST/manager/files
      ✓ Upload ossec.conf (637ms)
      ✓ Upload ossec.conf (overwrite=false) (419ms)
      ✓ Upload rules (new rule) (485ms)
      ✓ Upload rules (overwrite=true) (664ms)
      ✓ Upload rules (overwrite=false) (687ms)
      ✓ Upload decoder (overwrite=true) (648ms)
      ✓ Upload decoder (without overwrite parameter) (507ms)
      ✓ Upload list (overwrite=true) (457ms)
      ✓ Upload list (without overwrite parameter) (557ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (666ms)
      ✓ Request rules (local) (695ms)
      ✓ Request rules (global) (679ms)
      ✓ Request decoders (local) (707ms)
      ✓ Request decoders (global) (537ms)
      ✓ Request lists (614ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (576ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (438ms)
    DELETE/manager/files
      ✓ Delete rules (429ms)
      ✓ Delete decoders (410ms)
      ✓ Delete CDB list (351ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1671ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (383ms)
```

##### Cluster

```javascript
# mocha test/test_cluster.js --timeout=10000


  Cluster
    GET/cluster/nodes
      ✓ Request (708ms)
      ✓ Pagination (478ms)
      ✓ Retrieve all elements with limit=0 (470ms)
      ✓ Sort (452ms)
      ✓ Search (477ms)
      ✓ Filters: type (457ms)
      ✓ Filters: invalid type (1178ms)
      ✓ Select (496ms)
      ✓ Select 2 (474ms)
      ✓ Wrong select (478ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (494ms)
      ✓ Unexisting node stats (494ms)
      ✓ Analysisd stats (552ms)
      ✓ Remoted stats (510ms)
    GET/cluster/nodes/:node_name
      ✓ Request (463ms)
      ✓ Request wrong name (471ms)
    GET/cluster/status
      ✓ Request (522ms)
    GET/cluster/config
      ✓ Request (565ms)
    GET/cluster/healthcheck
      ✓ Request (907ms)
      ✓ Filter: node name (694ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (811ms)
      ✓ Upload ossec.conf (worker) (653ms)
      ✓ Upload new rules (745ms)
      ✓ Upload rules (overwrite=true) (657ms)
      ✓ Upload rules (overwrite=false) (549ms)
      ✓ Upload new decoder (468ms)
      ✓ Upload decoder (overwrite=true) (475ms)
      ✓ Upload decoder (without overwrite parameter) (522ms)
      ✓ Upload new list (522ms)
      ✓ Upload list (overwrite=true) (567ms)
      ✓ Upload list (overwrite=false) (448ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (530ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (1395ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (439ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (499ms)
      ✓ Request ossec.conf (worker) (568ms)
      ✓ Request rules (local) (461ms)
      ✓ Request rules (global) (503ms)
      ✓ Request decoders (local) (451ms)
      ✓ Request decoders (global) (535ms)
      ✓ Request lists (440ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (453ms)
      ✓ Request file from unexisting node (435ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (525ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (4658ms)
      ✓ Request validation (worker) (3382ms)
      ✓ Request validation (all nodes) (1955ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (407ms)
      ✓ Request validation (worker) (2001ms)
      ✓ Request validation (all nodes) (1722ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (2160ms)
      ✓ Request validation (worker) (737ms)
      ✓ Request validation (all nodes) (2318ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (568ms)
      ✓ Request validation (worker)
      ✓ Request validation (all nodes) (656ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (502ms)
      ✓ Delete decoders (master) (461ms)
      ✓ Delete CDB list (master) (393ms)
      ✓ Delete file with empty path
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (548ms)
      ✓ Request (master) (475ms)

```

Best regards

Demetrio.