### PR TITLE
Change user password store algorithm to secure bcrypt

### DIFF
--- a/scripts/configure_api.sh
+++ b/scripts/configure_api.sh
@@ -178,7 +178,7 @@ change_auth () {
         case $AUTH in
             [yY] ) edit_configuration "basic_auth" "yes"
 
-                   exec_cmd_bash "cd $API_PATH/configuration/auth && $API_PATH/node_modules/htpasswd/bin/htpasswd -bc user $USER $PASS";;
+                   exec_cmd_bash "cd $API_PATH/configuration/auth && $API_PATH/node_modules/htpasswd/bin/htpasswd -Bc user $USER $PASS";;
 
             [nN] ) auth="n"
                    print "Disabling authentication (not secure)."


### PR DESCRIPTION
A change of one letter base on htpasswd help:

```
# node htpasswd
Usage: htpasswd [options] [passwordfile] username [password]

Options:
  -V, --version    output the version number
  -b, --batch      Use the password from the command line rather than prompting for it. This option should be used with extreme care, since the password is clearly visible on the command line. For script use see the -i option.
  -i, --stdin      Read the password from stdin without verification (for script usage).
  -c, --create     Create a new file.
  -n, --nofile     Don't update file; display results on stdout.
  -m, --md5        Use MD5 encryption for passwords. This is the default.
  -B, --bcrypt     Use bcrypt encryption for passwords. This is currently considered to be very secure.
  -C, --cost       This flag is only allowed in combination with -B (bcrypt encryption). It sets the computing time used for the bcrypt algorithm (higher is more secure but slower, default: 5, valid: 4 to 31).
  -d, --crypt      Use crypt() encryption for passwords. This algorithm limits the password length to 8 characters. This algorithm is insecure by today's standards.
  -s, --sha        Use SHA encryption for passwords. This algorithm is insecure by today's standards.
  -p, --plaintext  Do not encrypt the password (plaintext).
  -D, --delete     Delete the specified user.
  -v, --verify     Verify password. Verify that the given password matches the password of the user stored in the specified htpasswd file.
  -h, --help       output usage information

        Examples:

          htpasswd [-cimBpsDv] [ -C cost ] passwordfile username
          htpasswd -b[cmBpsDv] [ -C cost ] passwordfile username password

          htpasswd -n[imBps] [ -C cost ] username
          htpasswd -nb[mBps] [ -C cost ] username password

```