### PR TITLE
Fix docstring in lists controller

### DIFF
--- a/controllers/lists.js
+++ b/controllers/lists.js
@@ -22,7 +22,6 @@ var router = require('express').Router();
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
  * @apiParam {String} [path] Filters by path.
- * @apiParam {String="enabled","disabled", "all"} [status] Filters the decoders by status.
  *
  * @apiDescription Returns the content of all CDB lists
  *


### PR DESCRIPTION
Hello team, this PR closes https://github.com/wazuh/wazuh-api/issues/383.

**API Test after fix:**
```
root@c3a3174807b8:/wazuh-api# curl -u foo:bar "http://localhost:55000/lists?pretty&limit=1"
{
   "error": 0,
   "data": {
      "totalItems": 1,
      "items": [
         {
            "path": "etc/lists/audit-keys",
            "items": [
               {
                  "key": "audit-wazuh-w",
                  "value": "write"
               },
               {
                  "key": "audit-wazuh-r",
                  "value": "read"
               },
               {
                  "key": "audit-wazuh-a",
                  "value": "attribute"
               },
               {
                  "key": "audit-wazuh-x",
                  "value": "execute"
               },
               {
                  "key": "audit-wazuh-c",
                  "value": "command"
               }
            ]
         }
      ]
   }
}
```