### PR TITLE
List GPG13 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.10.0]
+
+### Added
+
+- New API requests:
+    * `GET/rules/gpg13` ([#389](https://github.com/wazuh/wazuh-api/pull/389)).
+    
+- New filter in request `GET/rules`:
+    - `gpg13`: Filters the rules by gpg13 requirement ([#389](https://github.com/wazuh/wazuh-api/pull/389)).
+    
 ## [v3.9.0]
 
 ### Added

--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -45,7 +45,7 @@ router.get('/', cache(), function(req, res) {
                    'search':'search_param', 'status':'alphanumeric_param',
                    'group':'alphanumeric_param', 'level':'ranges', 'path':'paths',
                    'file':'alphanumeric_param', 'pci':'alphanumeric_param',
-                   'gdpr': 'alphanumeric_param'};
+                   'gdpr': 'alphanumeric_param', 'gpg13': 'alphanumeric_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
@@ -72,6 +72,8 @@ router.get('/', cache(), function(req, res) {
         data_request['arguments']['pci'] = req.query.pci;
     if ('gdpr' in req.query)
         data_request['arguments']['gdpr'] = req.query.gdpr;
+    if ('gpg13' in req.query)
+        data_request['arguments']['gpg13'] = req.query.gpg13;
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -156,6 +156,46 @@ router.get('/pci', cache(), function(req, res) {
 
 
 /**
+ * @api {get} /rules/gpg13 Get rule gpg13 requirements
+ * @apiName GetRulesGpg13
+ * @apiGroup Info
+ *
+ * @apiParam {Number} [offset] First element to return in the collection.
+ * @apiParam {Number} [limit=500] Maximum number of elements to return.
+ * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
+ * @apiParam {String} [search] Looks for elements with the specified string.
+ *
+ * @apiDescription Returns the GPG13 requirements of all rules.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/gpg13?offset=0&limit=10&pretty"
+ *
+ */
+router.get('/gpg13', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /rules/gpg13");
+
+    req.apicacheGroup = "rules";
+
+    var data_request = {'function': '/rules/gpg13', 'arguments': {}};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
+
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
+        return;
+
+    if ('offset' in req.query)
+        data_request['arguments']['offset'] = Number(req.query.offset);
+    if ('limit' in req.query)
+        data_request['arguments']['limit'] = Number(req.query.limit);
+    if ('sort' in req.query)
+        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
+    if ('search' in req.query)
+        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+
+/**
  * @api {get} /rules/gdpr Get rule gdpr requirements
  * @apiName GetRulesGdpr
  * @apiGroup Info


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-api/issues/388|

**The PR https://github.com/wazuh/wazuh/pull/3348 needs to be merged before.**

This PR adds the call for listing the GPG13 requirements:

```
# curl -u foo:bar -k -X GET "http://127.0.0.1:55000/rules/gpg13?pretty"

{
   "error": 0,
   "data": {
      "items": [
         "1.3",
         "10.1",
         "3.1",
         "3.2",
         "3.3",
         "3.5",
         "3.6",
         "3.7",
         "4.1",
         "4.10",
         "4.11",
         "4.12",
         "4.13",
         "4.14",
         "4.2",
         "4.3",
         "4.4",
         "4.6",
         "4.8",
         "7.1",
         "7.10",
         "7.13",
         "7.2",
         "7.5",
         "7.6",
         "7.8",
         "7.9",
         "71"
      ],
      "totalItems": 28
   }
}
```