### PR TITLE
Remove body parameters in DELETE requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.10.0]
+
+### Fixed
+- Fixed bug inserting duplicated agent without any errors ([#318](https://github.com/wazuh/wazuh-api/issues/318))
+
 ## [v3.9.0]
 
 ### Added

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -1074,7 +1074,7 @@ router.delete('/', function(req, res) {
         return;
     }
 
-    if ('purge' in req.query && req.query.pruge == true)
+    if ('purge' in req.query && req.query.purge == true)
         data_request['arguments']['purge'] = true;
     else
         data_request['arguments']['purge'] = false;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -1006,7 +1006,7 @@ router.delete('/group/:group_id', function(req, res) {
 
     if (!filter.check(req.params, filters_param, req, res))  // Filter with error (path params)
         return;
-    if (!filter.check(req.params, filters_query, req, res))  // Filter with error (query params)
+    if (!filter.check(req.query, filters_query, req, res))  // Filter with error (query params)
         return;
 
     data_request['arguments']['group_id'] = req.params.group_id;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -882,7 +882,7 @@ router.post('/group/:group_id', function(req, res) {
  * @apiDescription Removes a list of groups.
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["webserver","database"]}' "https://127.0.0.1:55000/agents/groups?pretty"
+ *     curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents/groups?ids=webserver,database&pretty"
  *
  */
 router.delete('/groups', function(req, res) {
@@ -890,11 +890,11 @@ router.delete('/groups', function(req, res) {
 
     var data_request = {'function': 'DELETE/agents/groups', 'arguments': {}};
 
-    if (!filter.check(req.body, {'ids':'array_names'}, req, res))  // Filter with error
+    if (!filter.check(req.query, {'ids':'array_names'}, req, res))  // Filter with error
         return;
 
-    if ('ids' in req.body){
-        data_request['arguments']['group_id'] = req.body.ids;
+    if ('ids' in req.query){
+        data_request['arguments']['group_id'] = req.query.ids;
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
     }else
         res_h.bad_request(req, res, 604, "Missing field: 'ids'");
@@ -994,22 +994,25 @@ router.delete('/:agent_id/group/:group_id', function(req, res) {
  * @apiDescription Remove a list of agents of a group
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -X DELETE -H "Content-Type:application/json" -d '{"ids":["001","002"]}' "https://localhost:55000/agents/group/dmz?pretty" -k
+ *     curl -u foo:bar -k -X DELETE "https://localhost:55000/agents/group/dmz?ids=001,002&pretty"
  *
  */
 router.delete('/group/:group_id', function(req, res) {
     logger.debug(req.connection.remoteAddress + " DELETE /agents/group/:group_id");
 
     var data_request = {'function': 'DELETE/agents/group/:group_id', 'arguments': {}};
-    var filters = {'group_id':'names', 'ids':'array_numbers'}
+    var filters_param = {'group_id': 'names'}
+    var filters_query = {'ids': 'array_numbers'}
 
-    if (!filter.check(req.params, filters, req, res))  // Filter with error
+    if (!filter.check(req.params, filters_param, req, res))  // Filter with error (path params)
+        return;
+    if (!filter.check(req.params, filters_query, req, res))  // Filter with error (query params)
         return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['agent_id_list'] = req.body.ids;
+    data_request['arguments']['agent_id_list'] = req.query.ids;
 
-    if ('ids' in req.body){
+    if ('ids' in req.query){
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
     }else
         res_h.bad_request(req, res, 604, "Missing field: 'ids'");
@@ -1053,36 +1056,31 @@ router.delete('/groups/:group_id', function(req, res) {
  * @apiDescription Removes agents, using a list of them or a criterion based on the status or time of the last connection. The Wazuh API must be restarted after removing an agent.
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["003","005"]}' "https://127.0.0.1:55000/agents?pretty&older_than=10s&purge"
+ *     curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents?pretty&older_than=10s&purge&ids=003,005"
  *
  */
 router.delete('/', function(req, res) {
     logger.debug(req.connection.remoteAddress + " DELETE /agents");
 
-    var data_request = { 'function': 'DELETE/agents/', 'arguments': {}};
-    var filter_body = { 'ids': 'array_numbers', 'purge': 'boolean'};
-    var filter_query = { 'older_than': 'timeframe_type', 'status': 'alphanumeric_param', 'purge': 'empty_boolean' };
+    var data_request = {'function': 'DELETE/agents/', 'arguments': {}};
+    var filters_query = {'older_than': 'timeframe_type', 'status': 'alphanumeric_param', 'purge': 'empty_boolean',
+                         'ids': 'array_numbers'};
 
-    if (!filter.check(req.body, filter_body, req, res))  // Filter with error
+    if (!filter.check(req.query, filters_query, req, res))  // Filter with error
         return;
 
-    if (!filter.check(req.query, filter_query, req, res))  // Filter with error
-        return;
-
-    if (!('ids' in req.body) && !('status' in req.query)){
+    if (!('ids' in req.query) && !('status' in req.query)){
         res_h.bad_request(req, res, 604, "Missing field: You have to specified 'ids' or status.");
         return;
     }
 
-    if ('purge' in req.body && 'purge' in req.query) // the most restrictive wins
-        data_request['arguments']['purge'] = (req.query.purge == 'true' || req.query.purge == '') && (req.body.purge == 'true' || req.body.purge == true);
-    else if ('purge' in req.body)
-        data_request['arguments']['purge'] = (req.body.purge == 'true' || req.body.purge == true);
-    else if ('purge' in req.query)
-        data_request['arguments']['purge'] = (req.query.purge == 'true' || req.query.purge == '');
+    if ('purge' in req.query && req.query.pruge == true)
+        data_request['arguments']['purge'] = true;
+    else
+        data_request['arguments']['purge'] = false;
 
-    if ('ids' in req.body)
-        data_request['arguments']['list_agent_ids'] = req.body.ids;
+    if ('ids' in req.query)
+        data_request['arguments']['list_agent_ids'] = req.query.ids;
 
     if ('older_than' in req.query)
         data_request['arguments']['older_than'] = req.query.older_than;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -894,7 +894,7 @@ router.delete('/groups', function(req, res) {
         return;
 
     if ('ids' in req.query){
-        data_request['arguments']['group_id'] = req.query.ids;
+        data_request['arguments']['group_id'] = req.query.ids.split(',');
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
     }else
         res_h.bad_request(req, res, 604, "Missing field: 'ids'");
@@ -1010,7 +1010,7 @@ router.delete('/group/:group_id', function(req, res) {
         return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['agent_id_list'] = req.query.ids;
+    data_request['arguments']['agent_id_list'] = req.query.ids.split(',');
 
     if ('ids' in req.query){
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
@@ -1080,7 +1080,7 @@ router.delete('/', function(req, res) {
         data_request['arguments']['purge'] = false;
 
     if ('ids' in req.query)
-        data_request['arguments']['list_agent_ids'] = req.query.ids;
+        data_request['arguments']['list_agent_ids'] = req.query.ids.split(',');
 
     if ('older_than' in req.query)
         data_request['arguments']['older_than'] = req.query.older_than;

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -877,7 +877,7 @@ router.post('/group/:group_id', function(req, res) {
  * @apiName DeleteAgentsGroups
  * @apiGroup Delete
  *
- * @apiParam {String[]} ids Array of group ID's.
+ * @apiParam {String} Name of groups separated by commas.
  *
  * @apiDescription Removes a list of groups.
  *
@@ -988,7 +988,7 @@ router.delete('/:agent_id/group/:group_id', function(req, res) {
  * @apiName DeleteGroupAgents
  * @apiGroup Groups
  *
- * @apiParam {List} agent_id Agent ID list.
+ * @apiParam {String} agent_id Agent IDs separated by commas.
  * @apiParam {String} group_id Group ID.
  *
  * @apiDescription Remove a list of agents of a group
@@ -1048,7 +1048,7 @@ router.delete('/groups/:group_id', function(req, res) {
  * @apiName DeleteAgents
  * @apiGroup Delete
  *
- * @apiParam {String[]} ids Array of agent ID's.
+ * @apiParam {String} Agent IDs separated by commas.
  * @apiParam {Boolean} purge Delete an agent from the key store.
  * @apiParam {String="active", "pending", "neverconnected", "disconnected"} [status] Filters by agent status. Use commas to enter multiple statuses.
  * @apiParam {String} older_than Filters out disconnected agents for longer than specified. Time in seconds, '[n_days]d', '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never connected agents, uses the register date. Default value: 7d.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wazuh_api",
-  "version": "3.9.1",
-  "revision": "3913",
+  "version": "3.10.0",
+  "revision": "31000",
   "description": "Wazuh API.",
   "main": "app.js",
   "author": "Wazuh",

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -2255,7 +2255,7 @@ describe('Agents', function() {
         it('Filter: older_than, status and ids', function (done) {
             setTimeout(function(){
                 request(common.url)
-                    .delete("/agents?purge&ids=" + agent1_id + "older_than=1s&status=neverconnected")
+                    .delete("/agents?purge&ids=" + agent1_id + "&older_than=1s&status=neverconnected")
                     .auth(common.credentials.user, common.credentials.password)
                     .expect("Content-type", /json/)
                     .expect(200)

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -20,7 +20,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 var disconnected_agent_properties = ['status', 'ip', 'id', 'name', 'dateAdd'];
 var manager_properties = disconnected_agent_properties.concat(['version', 'manager', 'lastKeepAlive', 'os']);
 var agent_properties = manager_properties.concat(['configSum', 'mergedSum', 'group']);
-var agent_os_properties = ['major', 'name', 'uname', 'platform', 'version', 'codename', 'arch'];
+var agent_os_properties = ['major', 'name', 'uname', 'platform', 'version', 'arch'];
 
 describe('Agents', function() {
 

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -2255,8 +2255,7 @@ describe('Agents', function() {
         it('Filter: older_than, status and ids', function (done) {
             setTimeout(function(){
                 request(common.url)
-                    .delete("/agents?purge&older_than=1s&status=neverconnected")
-                    .send({ 'ids': [agent1_id]})
+                    .delete("/agents?purge&ids=" + agent1_id + "older_than=1s&status=neverconnected")
                     .auth(common.credentials.user, common.credentials.password)
                     .expect("Content-type", /json/)
                     .expect(200)


### PR DESCRIPTION
Hi team,

This PR closes [3388](https://github.com/wazuh/wazuh/issues/3388). `body` parameters were removed from `DELETE` requests in our API in order to follow `OpenAPI` standard.

In issue [3388](https://github.com/wazuh/wazuh/issues/3388) there are more details about this improvement.

Best regards,

Demetrio.
