### PR TITLE
Update API rules endpoints to support HIPAA and NIST-800-53 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.10.0]
+
+- New API requests:
+    * `GET/rules/hipaa` ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+    * `GET/rules/nist-800-53` ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+- New filters in request `GET/rules`:
+    - `hipaa`: Filters the rules by hipaa requirement ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+    - `nist-800-53`: Filters the rules by nist-800-53 requirement ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+
 ## [v3.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New API requests:
-    * `GET/rules/hipaa` ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
-    * `GET/rules/nist-800-53` ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+    * `GET/rules/hipaa` ([#397](https://github.com/wazuh/wazuh-api/pull/397)).
+    * `GET/rules/nist-800-53` ([#397](https://github.com/wazuh/wazuh-api/pull/397)).
     * `GET/rules/gpg13` ([#389](https://github.com/wazuh/wazuh-api/pull/389)).
 - New filters in request `GET/rules`:
-    - `hipaa`: Filters the rules by hipaa requirement ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
-    - `nist-800-53`: Filters the rules by nist-800-53 requirement ([#386](https://github.com/wazuh/wazuh-api/issues/386)).
+    - `hipaa`: Filters the rules by hipaa requirement ([#397](https://github.com/wazuh/wazuh-api/pull/397)).
+    - `nist-800-53`: Filters the rules by nist-800-53 requirement ([#397](https://github.com/wazuh/wazuh-api/pull/397)).
     - `gpg13`: Filters the rules by gpg13 requirement ([#389](https://github.com/wazuh/wazuh-api/pull/389)).
 
 ### Fixed

--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -30,6 +30,7 @@ var router = require('express').Router();
  * @apiParam {String} [gdpr] Filters the rules by gdpr requirement.
  * @apiParam {String} [hipaa] Filters the rules by hipaa requirement.
  * @apiParam {String} [nist-800-53] Filters the rules by nist-800-53 requirement.
+ * @apiParam {String} [gpg13] Filters the rules by gpg13 requirement.
  * @apiDescription Returns all rules.
  *
  * @apiExample {curl} Example usage:

--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -77,7 +77,7 @@ router.get('/', cache(), function(req, res) {
     if ('hipaa' in req.query)
         data_request['arguments']['hipaa'] = req.query.hipaa;
     if ('nist-800-53' in req.query)
-        data_request['arguments']['nist-800-53'] = req.query['nist-800-53'];
+        data_request['arguments']['nist_800_53'] = req.query['nist-800-53'];
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })

--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -27,8 +27,9 @@ var router = require('express').Router();
  * @apiParam {String} [path] Filters the rules by path.
  * @apiParam {String} [file] Filters the rules by file name.
  * @apiParam {String} [pci] Filters the rules by pci requirement.
- * @apiParam {String} [gdpr] Filters the rules by gdpr.
- *
+ * @apiParam {String} [gdpr] Filters the rules by gdpr requirement.
+ * @apiParam {String} [hipaa] Filters the rules by hipaa requirement.
+ * @apiParam {String} [nist-800-53] Filters the rules by nist-800-53 requirement.
  * @apiDescription Returns all rules.
  *
  * @apiExample {curl} Example usage:
@@ -45,7 +46,8 @@ router.get('/', cache(), function(req, res) {
                    'search':'search_param', 'status':'alphanumeric_param',
                    'group':'alphanumeric_param', 'level':'ranges', 'path':'paths',
                    'file':'alphanumeric_param', 'pci':'alphanumeric_param',
-                   'gdpr': 'alphanumeric_param'};
+                   'gdpr': 'alphanumeric_param', 'hipaa': 'alphanumeric_param',
+                   'nist-800-53': 'alphanumeric_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;
@@ -72,6 +74,10 @@ router.get('/', cache(), function(req, res) {
         data_request['arguments']['pci'] = req.query.pci;
     if ('gdpr' in req.query)
         data_request['arguments']['gdpr'] = req.query.gdpr;
+    if ('hipaa' in req.query)
+        data_request['arguments']['hipaa'] = req.query.hipaa;
+    if ('nist-800-53' in req.query)
+        data_request['arguments']['nist-800-53'] = req.query['nist-800-53'];
 
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
@@ -177,6 +183,86 @@ router.get('/gdpr', cache(), function(req, res) {
     req.apicacheGroup = "rules";
 
     var data_request = {'function': '/rules/gdpr', 'arguments': {}};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
+
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
+        return;
+
+    if ('offset' in req.query)
+        data_request['arguments']['offset'] = Number(req.query.offset);
+    if ('limit' in req.query)
+        data_request['arguments']['limit'] = Number(req.query.limit);
+    if ('sort' in req.query)
+        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
+    if ('search' in req.query)
+        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+
+/**
+ * @api {get} /rules/hipaa Get rule hipaa requirements
+ * @apiName GetRulesHipaa
+ * @apiGroup Info
+ *
+ * @apiParam {Number} [offset] First element to return in the collection.
+ * @apiParam {Number} [limit=500] Maximum number of elements to return.
+ * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
+ * @apiParam {String} [search] Looks for elements with the specified string.
+ *
+ * @apiDescription Returns the HIPAA requirements of all rules.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/hipaa?offset=0&limit=10&pretty"
+ *
+ */
+router.get('/hipaa', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /rules/hipaa");
+
+    req.apicacheGroup = "rules";
+
+    var data_request = {'function': '/rules/hipaa', 'arguments': {}};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
+
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
+        return;
+
+    if ('offset' in req.query)
+        data_request['arguments']['offset'] = Number(req.query.offset);
+    if ('limit' in req.query)
+        data_request['arguments']['limit'] = Number(req.query.limit);
+    if ('sort' in req.query)
+        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
+    if ('search' in req.query)
+        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+
+/**
+ * @api {get} /rules/nist-800-53 Get rule nist-800-53 requirements
+ * @apiName GetRulesNist-800-53
+ * @apiGroup Info
+ *
+ * @apiParam {Number} [offset] First element to return in the collection.
+ * @apiParam {Number} [limit=500] Maximum number of elements to return.
+ * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
+ * @apiParam {String} [search] Looks for elements with the specified string.
+ *
+ * @apiDescription Returns the NIST-800-53 requirements of all rules.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/nist-800-53?offset=0&limit=10&pretty"
+ *
+ */
+router.get('/nist-800-53', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /rules/nist-800-53");
+
+    req.apicacheGroup = "rules";
+
+    var data_request = {'function': '/rules/nist-800-53', 'arguments': {}};
     var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -15,7 +15,7 @@ var request = require('supertest');
 var common = require('./common.js');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-rule_fields = ['status', 'gdpr', 'pci', 'description', 'path', 'file', 'level', 'groups', 'id', 'details']
+rule_fields = ['status', 'gdpr', 'pci', 'hipaa', 'nist-800-53','description', 'path', 'file', 'level', 'groups', 'id', 'details']
 
 describe('Rules', function() {
 
@@ -280,6 +280,44 @@ describe('Rules', function() {
         it('Filters: gdpr', function(done) {
             request(common.url)
             .get("/rules?gdpr=II_5.1.f")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array)
+                res.body.data.items[0].should.have.properties(rule_fields);
+                done();
+            });
+        });
+
+        it('Filters: hipaa', function(done) {
+            request(common.url)
+            .get("/rules?hipaa=164.312.b")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array)
+                res.body.data.items[0].should.have.properties(rule_fields);
+                done();
+            });
+        });
+
+        it('Filters: nist-800-53', function(done) {
+            request(common.url)
+            .get("/rules?nist-800-53=AU.3")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -626,6 +664,226 @@ describe('Rules', function() {
         });
 
     });  // GET/rules/gdpr
+
+    describe('GET/rules/hipaa', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .get("/rules/hipaa")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Pagination', function(done) {
+            request(common.url)
+            .get("/rules/hipaa?offset=0&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.items.should.be.instanceof(Array).and.have.lengthOf(1);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Retrieve all elements with limit=0', function(done) {
+            request(common.url)
+            .get("/rules/hipaa?limit=0")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1406);
+                done();
+            });
+        });
+
+        it('Sort', function(done) {
+            request(common.url)
+            .get("/rules/hipaa?sort=-")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Search', function(done) {
+            request(common.url)
+            .get("/rules/hipaa?search=164")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Filters: Invalid filter', function(done) {
+            request(common.url)
+            .get("/rules/hipaa?random")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(604);
+                done();
+            });
+        });
+
+    });  // GET/rules/hipaa
+
+    describe('GET/rules/nist-800-53', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Pagination', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53?offset=0&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.items.should.be.instanceof(Array).and.have.lengthOf(1);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Retrieve all elements with limit=0', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53?limit=0")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1406);
+                done();
+            });
+        });
+
+        it('Sort', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53?sort=-")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Search', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53?search=AU")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Filters: Invalid filter', function(done) {
+            request(common.url)
+            .get("/rules/nist-800-53?random")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(604);
+                done();
+            });
+        });
+
+    });  // GET/rules/nist-800-53
 
     describe('GET/rules/files', function() {
 

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -15,7 +15,7 @@ var request = require('supertest');
 var common = require('./common.js');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-rule_fields = ['status', 'gdpr', 'pci', 'hipaa', 'nist-800-53','description', 'path', 'file', 'level', 'groups', 'id', 'details']
+rule_fields = ['status', 'gdpr', 'pci', 'gpg13', 'hipaa', 'nist-800-53','description', 'path', 'file', 'level', 'groups', 'id', 'details']
 
 describe('Rules', function() {
 
@@ -318,6 +318,25 @@ describe('Rules', function() {
         it('Filters: nist-800-53', function(done) {
             request(common.url)
             .get("/rules?nist-800-53=AU.3")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array)
+                res.body.data.items[0].should.have.properties(rule_fields);
+                done();
+            });
+        });
+
+        it('Filters: gpg13', function(done) {
+            request(common.url)
+            .get("/rules?gpg13=10.1")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -664,6 +683,116 @@ describe('Rules', function() {
         });
 
     });  // GET/rules/gdpr
+
+    describe('GET/rules/gpg13', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .get("/rules/gpg13")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Pagination', function(done) {
+            request(common.url)
+            .get("/rules/gpg13?offset=0&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.items.should.be.instanceof(Array).and.have.lengthOf(1);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Retrieve all elements with limit=0', function(done) {
+            request(common.url)
+            .get("/rules/gpg13?limit=0")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1406);
+                done();
+            });
+        });
+
+        it('Sort', function(done) {
+            request(common.url)
+            .get("/rules/gpg13?sort=-")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Search', function(done) {
+            request(common.url)
+            .get("/rules/gpg13?search=10.1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Filters: Invalid filter', function(done) {
+            request(common.url)
+            .get("/rules/gpg13?random")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(604);
+                done();
+            });
+        });
+
+    });  // GET/rules/gpg13
 
     describe('GET/rules/hipaa', function() {
 

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -317,7 +317,7 @@ describe('Rules', function() {
 
         it('Filters: nist-800-53', function(done) {
             request(common.url)
-            .get("/rules?nist-800-53=AU.3")
+            .get("/rules?nist-800-53=AU.1")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)


### PR DESCRIPTION
Hi team, this PR is related to wazuh/wazuh-api#386.

Best regards,

David J. Iglesias

**Mocha tests results:**
```javascript
  Rules
    GET/rules
      ✓ Request (283ms)
      ✓ Pagination (264ms)
      ✓ Retrieve all elements with limit=0 (265ms)
      ✓ Sort (271ms)
      ✓ Search (352ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (270ms)
      ✓ Filters: group (289ms)
      ✓ Filters: level (1) (276ms)
      ✓ Filters: level (2) (376ms)
      ✓ Filters: path (275ms)
      ✓ Filters: file (270ms)
      ✓ Filters: pci (338ms)
      ✓ Filters: gdpr (269ms)
      ✓ Filters: hipaa (259ms)
      ✓ Filters: nist-800-53 (259ms)
      ✓ Filters: gpg13 (273ms)
    GET/rules/groups
      ✓ Request (266ms)
      ✓ Pagination (262ms)
      ✓ Retrieve all elements with limit=0 (264ms)
      ✓ Sort (263ms)
      ✓ Search (265ms)
      ✓ Filters: Invalid filter
    GET/rules/pci
      ✓ Request (266ms)
      ✓ Pagination (265ms)
      ✓ Retrieve all elements with limit=0 (266ms)
      ✓ Sort (265ms)
      ✓ Search (265ms)
      ✓ Filters: Invalid filter
    GET/rules/gdpr
      ✓ Request (265ms)
      ✓ Pagination (266ms)
      ✓ Retrieve all elements with limit=0 (265ms)
      ✓ Sort (266ms)
      ✓ Search (265ms)
      ✓ Filters: Invalid filter
    GET/rules/gpg13
      ✓ Request (265ms)
      ✓ Pagination (269ms)
      ✓ Retrieve all elements with limit=0 (276ms)
      ✓ Sort (266ms)
      ✓ Search (266ms)
      ✓ Filters: Invalid filter
    GET/rules/hipaa
      ✓ Request (266ms)
      ✓ Pagination (266ms)
      ✓ Retrieve all elements with limit=0 (267ms)
      ✓ Sort (266ms)
      ✓ Search (267ms)
      ✓ Filters: Invalid filter
    GET/rules/nist-800-53
      ✓ Request (266ms)
      ✓ Pagination (266ms)
      ✓ Retrieve all elements with limit=0 (267ms)
      ✓ Sort (266ms)
      ✓ Search (265ms)
      ✓ Filters: Invalid filter
    GET/rules/files
      ✓ Request (164ms)
      ✓ Pagination (165ms)
      ✓ Retrieve all elements with limit=0 (165ms)
      ✓ Sort (163ms)
      ✓ Search (163ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (163ms)
      ✓ Filters: download (164ms)
    GET/rules/:rule_id
      ✓ Request (261ms)
      ✓ Pagination (262ms)
      ✓ Retrieve all elements with limit=0 (263ms)
      ✓ Sort (260ms)
      ✓ Search (260ms)
      ✓ Filters: Invalid filter
      ✓ Params: Bad rule id
      ✓ Params: No rule (262ms)


  71 passing (15s)
```