### PR TITLE
Fix API installation script for Docker

### DIFF
--- a/install_api.sh
+++ b/install_api.sh
@@ -213,10 +213,10 @@ previous_checks() {
     check_program_installed "curl"
     check_program_installed "gcc"
 
-    NODE_DIR=$(which nodejs 2> /dev/null)
+    NODE_DIR=$(command -v nodejs 2> /dev/null)
 
     if [ "X$NODE_DIR" = "X" ]; then
-        NODE_DIR=$(which node 2> /dev/null)
+        NODE_DIR=$(command -v node 2> /dev/null)
 
         if [ "X$NODE_DIR" = "X" ]; then
             echo "NodeJS binaries not found. Is NodeJS installed?"

--- a/scripts/install_daemon.sh
+++ b/scripts/install_daemon.sh
@@ -63,7 +63,7 @@ fi
 
 # Install for systemd
 
-if [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
+if command -v systemctl > /dev/null 2>&1 && systemctl > /dev/null 2>&1; then
     echo "Installing for systemd"
 
     sed "s:^ExecStart=.*:ExecStart=$BIN_DIR $APP_PATH:g" $SCRIPTS_PATH/wazuh-api.service > $SCRIPTS_PATH/wazuh-api.service.tmp
@@ -76,7 +76,7 @@ if [ -n "$(ps -e | egrep ^\ *1\ .*systemd$)" ]; then
 
 # Install for SysVinit / Upstart
 
-elif [ -n "$(ps -e | egrep ^\ *1\ .*init$)" ]; then
+elif command -v service > /dev/null 2>&1; then
     echo "Installing for SysVinit"
 
     sed "s:^BIN_DIR=.*:BIN_DIR=\"$BIN_DIR\":g" $SCRIPTS_PATH/wazuh-api > $SCRIPTS_PATH/wazuh-api.tmp

--- a/scripts/install_daemon.sh
+++ b/scripts/install_daemon.sh
@@ -50,10 +50,10 @@ fi
 
 # Binary name for NodeJS
 
-BIN_DIR=$(which nodejs 2> /dev/null)
+BIN_DIR=$(command -v nodejs 2> /dev/null)
 
 if [ "X$BIN_DIR" = "X" ]; then
-    BIN_DIR=$(which node 2> /dev/null)
+    BIN_DIR=$(command -v node 2> /dev/null)
 
     if [ "X$BIN_DIR" = "X" ]; then
         echo "NodeJS binaries not found. Is NodeJS installed?"

--- a/scripts/install_daemon.sh
+++ b/scripts/install_daemon.sh
@@ -86,7 +86,7 @@ elif command -v service > /dev/null 2>&1; then
     rm $SCRIPTS_PATH/wazuh-api.tmp
 
     enabled=true
-    if [ -r "/etc/redhat-release" ] || [ -r "/etc/SuSE-release" ]; then
+    if command -v chkconfig > /dev/null 2>&1; then
         /sbin/chkconfig --add wazuh-api > /dev/null 2>&1
     elif [ -f "/usr/sbin/update-rc.d" ] || [ -n "$(ps -e | egrep upstart)" ]; then
         update-rc.d wazuh-api defaults


### PR DESCRIPTION
Hi team,

This PR closes #407 and #402. After applying this fix, it is possible to install Wazuh API in a Docker container with `CentOS 7` without installing `which` package.

Best regards,

Demetrio.