### PR TITLE
Delete ossec_path input parameter

### DIFF
--- a/helpers/execute.js
+++ b/helpers/execute.js
@@ -35,8 +35,6 @@ exports.exec = function(cmd, args, stdin, callback) {
         return;
     }
 
-    stdin['ossec_path'] = config.ossec_path;
-
     // log
     stdin['arguments']['wait_for_complete'] = disable_timeout;
     var full_cmd = "CMD - Command: " + cmd + " args:" + args.join(' ') + " stdin:" + JSON.stringify(stdin);

--- a/models/wazuh-api.py
+++ b/models/wazuh-api.py
@@ -136,14 +136,8 @@ if __name__ == "__main__":
         print_json("Wazuh-Python Internal Error: 'JSON input' must have the 'function' key", 1000)
         exit(1)
 
-    if 'ossec_path' not in request:
-        print_json("Wazuh-Python Internal Error: 'JSON input' must have the 'ossec_path' key", 1000)
-        exit(1)
-
     # Main
     try:
-        wazuh = Wazuh(ossec_path=request['ossec_path'])
-
         before = time.time()
 
         if list_f:


### PR DESCRIPTION
This PR closes #406 .

This PR must be merged after https://github.com/wazuh/wazuh/pull/3548.

After changes in https://github.com/wazuh/wazuh/pull/3548, the Python script in charge of importing the framework does not need the path to be passed in every request, since `common.py` calculates the Wazuh installation path dinamically.

Tests have been performed in https://github.com/wazuh/wazuh/pull/3548 with positive results.