### PR TITLE
New endpoint for getting a full agents summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.11.0]
+
+### Added
+
+- New API requests:
+    * `GET/agents/full_summary` ([#428](https://github.com/wazuh/wazuh-api/pull/428)).
+
 ## [v3.10.0]
 
 ### Added

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -74,6 +74,26 @@ router.get('/summary', cache(), function(req, res) {
 })
 
 /**
+ * @api {get} /agents/full_summary Get a full summary of agents
+ * @apiName GetAgentsFullSummary
+ * @apiGroup Info
+ *
+ * @apiDescription Returns a dictionary with a full summary of agents.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/full_summary?pretty"
+ *
+ */
+router.get('/full_summary', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /agents/full_summary");
+
+    req.apicacheGroup = "agents";
+
+    var data_request = {'function': '/agents/full_summary', 'arguments': {}};
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {get} /agents/summary/os Get OS summary
  * @apiName GetOSSummary
  * @apiGroup Info

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -498,6 +498,73 @@ describe('Agents', function() {
 
     });  // GET/agents/summary
 
+    describe('GET/agents/full_summary', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .get("/agents/full_summary")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err)
+
+                res.body.should.have.properties(['error', 'data'])
+
+                res.body.error.should.equal(0)
+                res.body.data.should.have.properties(['unique_node_names', 'groups', 'unique_agent_os',
+                                                      'unique_agent_version', 'summary', 'last_registered_agent'])
+                // unique_node_names
+                res.body.data.unique_node_names.should.have.properties(['items', 'totalItems'])
+                res.body.data.unique_node_names.should.be.an.integer
+                res.body.data.unique_node_names.items[0].should.have.properties(['count', 'node_name'])
+                res.body.data.unique_node_names.items[0].count.should.be.an.integer
+                res.body.data.unique_node_names.items[0].node_name.should.be.equal('master')
+                res.body.data.unique_node_names.items[1].should.have.properties(['count', 'node_name'])
+                res.body.data.unique_node_names.items[1].count.should.be.an.integer
+                res.body.data.unique_node_names.items[1].node_name.should.be.equal('worker-1')
+                res.body.data.unique_node_names.items[2].should.have.properties(['count', 'node_name'])
+                res.body.data.unique_node_names.items[2].count.should.be.an.integer
+                res.body.data.unique_node_names.items[2].node_name.should.be.equal('worker-2')
+                // groups
+                res.body.data.groups.should.have.properties(['items', 'totalItems'])
+                res.body.data.groups.should.be.an.integer
+                res.body.data.groups.items[0].should.have.properties(['count', 'name', 'mergedSum', 'configSum'])
+                // unique_agent_os
+                res.body.data.unique_agent_os.should.have.properties(['items', 'totalItems'])
+                res.body.data.unique_agent_os.should.be.an.integer
+                res.body.data.unique_agent_os.items[0].should.have.properties(['os', 'count'])
+                res.body.data.unique_agent_os.items[0].os.should.have.properties(['name', 'platform', 'version'])
+                res.body.data.unique_agent_os.items[0].count.should.be.an.integer
+                // unique_agent_version
+                res.body.data.unique_agent_version.should.have.properties(['items', 'totalItems'])
+                res.body.data.unique_agent_version.should.be.an.integer
+                res.body.data.unique_agent_version.items[0].should.have.properties(['count', 'version'])
+                res.body.data.unique_agent_version.items[0].count.should.be.an.integer
+                res.body.data.unique_agent_version.items[0].version.should.be.String
+                // summary
+                res.body.data.summary.should.have.properties(['Total', 'Active', 'Disconnected', 'Never connected', 'Pending'])
+                res.body.data.summary['Active'].should.be.above(0)
+                res.body.data.summary['Total'].should.be.above(0)
+                res.body.data.summary['Disconnected'].should.be.an.integer
+                res.body.data.summary['Never connected'].should.be.an.integer
+                res.body.data.summary['Pending'].should.be.an.integer
+                // last_registered_agent
+                res.body.data.last_registered_agent.should.have.properties(['os', 'ip', 'node_name', 'name', 'dateAdd',
+                                                                           'id', 'manager', 'mergedSum', 'lastKeepAlive',
+                                                                           'group', 'version', 'configSum', 'status',
+                                                                           'registerIP'])
+                res.body.data.last_registered_agent.os.should.have.properties(['arch', 'codename', 'major', 'name',
+                                                                               'platform', 'uname', 'version'])
+                res.body.data.last_registered_agent.group.should.be.an.Array
+
+                done()
+
+            });
+        });
+
+    });  // GET/agents/full_summary
+
     describe('GET/agents/summary/os', function() {
 
         it('Request', function(done) {


### PR DESCRIPTION
Hi team,

This PR closes #426. I added the endpoint which was required in this issue. Below there is an example of this endpoint:

```bash
# curl -u foo:bar "localhost:55000/agents/full_summary?pretty"
{
   "error": 0,
   "data": {
      "unique_node_names": {
         "items": [
            {
               "node_name": "master",
               "count": 2
            },
            {
               "node_name": "worker-1",
               "count": 1
            },
            {
               "node_name": "worker-2",
               "count": 1
            }
         ],
         "totalItems": 4
      },
      "groups": {
         "items": [
            {
               "count": 3,
               "name": "default",
               "mergedSum": "ddda4e15b99efad1d3be7ae9d7ff14ff",
               "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
               "count": 0,
               "name": "dmz",
               "mergedSum": "dd77862c4a41ae1b3854d67143f3d3e4",
               "configSum": "ab73af41699f13fdd81903b5f23d8d00"
            },
            {
               "count": 0,
               "name": "testsagentconf",
               "mergedSum": "2acdb385658097abb9528aa5ec18c490",
               "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
            },
            {
               "count": 0,
               "name": "testsagentconf2",
               "mergedSum": "391ae29c1b0355c610f45bf133d5ea55",
               "configSum": "297b4cea942e0b7d2d9c59f9433e3e97"
            }
         ],
         "totalItems": 4
      },
      "unique_agent_os": {
         "items": [
            {
               "os": {
                  "name": "CentOS Linux",
                  "platform": "centos",
                  "version": "7.6"
               },
               "count": 3
            },
            {
               "os": {
                  "name": "CentOS Linux",
                  "platform": "centos",
                  "version": "7"
               },
               "count": 1
            }
         ],
         "totalItems": 4
      },
      "summary": {
         "Total": 4,
         "Active": 4,
         "Disconnected": 0,
         "Never connected": 0,
         "Pending": 0
      },
      "unique_agent_version": {
         "items": [
            {
               "count": 1,
               "version": "Wazuh v3.11.0"
            },
            {
               "count": 2,
               "version": "Wazuh v3.9.3"
            },
            {
               "count": 1,
               "version": "Wazuh v3.5.0"
            }
         ],
         "totalItems": 4
      },
      "last_registered_agent": {
         "os": {
            "arch": "x86_64",
            "codename": "Core",
            "major": "7",
            "name": "CentOS Linux",
            "platform": "centos",
            "uname": "Linux |7e2159a46bff |5.2.5-200.fc30.x86_64 |#1 SMP Wed Jul 31 14:37:17 UTC 2019 |x86_64",
            "version": "7"
         },
         "registerIP": "172.30.0.7",
         "mergedSum": "ddda4e15b99efad1d3be7ae9d7ff14ff",
         "ip": "172.30.0.7",
         "group": [
            "default"
         ],
         "name": "7e2159a46bff",
         "id": "003",
         "status": "Active",
         "lastKeepAlive": "2019-08-09 07:03:18",
         "configSum": "ab73af41699f13fdd81903b5f23d8d00",
         "dateAdd": "2019-08-08 11:25:03",
         "node_name": "worker-2",
         "version": "Wazuh v3.5.0",
         "manager": "636a34fa474a"
      }
   }
}
```

A `mocha` test was added too:
```javascript
GET/agents/full_summary
      ✓ Request (266ms)
```