### PR TITLE
New endpoint for restarting agents by group

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -627,6 +627,32 @@ router.post('/restart', function(req, res) {
 })
 
 /**
+ * @api {put} /agents/groups/:group_id/restart Restart agents which belong to a group
+ * @apiName PutAgentsGroupsRestart
+ * @apiGroup Restart
+ *
+ * @apiParam {String} Name of group
+ *
+ * @apiDescription Restarts agents which belong to a group
+ *
+ * @apiExample {curl} Example usage*:
+ *     curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/groups/dmz/restart?pretty"
+ *
+ */
+router.put('/groups/:group_id/restart', function(req, res) {
+    logger.debug(req.connection.remoteAddress + " PUT /agents/groups/:group_id/restart");
+
+    var data_request = {'function': 'PUT/agents/groups/:group_id/restart', 'arguments': {}};
+
+    if (!filter.check(req.params, {'group_id': 'names'}, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['group_id'] = req.params.group_id;
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+/**
  * @api {put} /agents/:agent_id/restart Restart an agent
  * @apiName PutAgentsRestartId
  * @apiGroup Restart

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -3076,4 +3076,60 @@ describe('Agents', function() {
 
     });  // POST/agents/restart
 
+    describe('PUT/agents/groups/:group_id/restart', function() {
+
+        it('Request', function(done) {
+            this.timeout(common.timeout);
+
+            request(common.url)
+            .put("/agents/groups/default/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.should.be.type('object');
+                res.body.data.should.have.properties(['msg', 'affected_agents']);
+                res.body.data.affected_agents.sort().should.be.eql(['001', '002', '003'].sort());
+                res.body.data.msg.should.equal('All selected agents were restarted');
+                done();
+            });
+        });
+
+        it('Params: Bad group id', function(done) {
+            request(common.url)
+            .put("/agents/groups/wrong-group/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1710);
+                done();
+            });
+        });
+
+        it('Group without agents', function(done) {
+            request(common.url)
+            .put("/agents/groups/dmz/restart")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1732);
+                done();
+            });
+        });
+
+    });  // PUT/agents/groups/:group_id/restart
+
 });  // Agents


### PR DESCRIPTION
Hi team,

This PR closes #411. I added a new endpoint for restarting agents by group:

```bash
# curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/groups/default/restart?pretty"
{
   "error": 0,
   "data": {
      "msg": "All selected agents were restarted",
      "affected_agents": [
         "001",
         "002",
         "003"
      ]
   }
}
```

```bash
# curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/groups/dmz/restart?pretty"
{
   "error": 1732,
   "message": "No agents selected"
}
```

```
# curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/groups/dmzzz/restart?pretty"
{
   "error": 1710,
   "message": "The group does not exist"
}
```

There are more details about mocha and unit tests in #411.

Best regards,

Demetrio.