### PR TITLE
Fix mocha tests for 3.10 (SCA and rules)

### DIFF
--- a/test/environment/docker/centos/wazuh-manager/master-ossec.conf
+++ b/test/environment/docker/centos/wazuh-manager/master-ossec.conf
@@ -91,10 +91,8 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
     <policies>
-      <policy>cis_rhel7_linux_rcl.yml</policy>
-      <policy>system_audit_rcl.yml</policy>
-      <policy>system_audit_ssh.yml</policy>
-      <policy>system_audit_pw.yml</policy>
+      <policy>cis_rhel7_linux.yml</policy>
+      <policy>sca_unix_audit.yml.disabled</policy>
     </policies>
   </sca>
   <wodle name="vulnerability-detector">

--- a/test/environment/docker/centos/wazuh-manager/worker-ossec.conf
+++ b/test/environment/docker/centos/wazuh-manager/worker-ossec.conf
@@ -91,10 +91,8 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
     <policies>
-      <policy>cis_rhel7_linux_rcl.yml</policy>
-      <policy>system_audit_rcl.yml</policy>
-      <policy>system_audit_ssh.yml</policy>
-      <policy>system_audit_pw.yml</policy>
+      <policy>cis_rhel7_linux.yml</policy>
+      <policy>sca_unix_audit.yml.disabled</policy>
     </policies>
   </sca>
   <wodle name="vulnerability-detector">

--- a/test/environment/docker/ubuntu/wazuh-manager/master-ossec.conf
+++ b/test/environment/docker/ubuntu/wazuh-manager/master-ossec.conf
@@ -86,10 +86,9 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
     <policies>
-      <policy>cis_debian_linux_rcl.yml</policy>
-      <policy>system_audit_rcl.yml</policy>
-      <policy>system_audit_ssh.yml</policy>
-      <policy>system_audit_pw.yml</policy>
+      <policy>cis_debian9_L1.yml</policy>
+      <policy>cis_debian9_L2.yml</policy>
+      <policy>sca_unix_audit.yml.disabled</policy>
     </policies>
   </sca>
   <wodle name="vulnerability-detector">

--- a/test/environment/docker/ubuntu/wazuh-manager/worker-ossec.conf
+++ b/test/environment/docker/ubuntu/wazuh-manager/worker-ossec.conf
@@ -86,10 +86,9 @@ Mailing list: https://groups.google.com/forum/#!forum/wazuh
     <interval>12h</interval>
     <skip_nfs>yes</skip_nfs>
     <policies>
-      <policy>cis_debian_linux_rcl.yml</policy>
-      <policy>system_audit_rcl.yml</policy>
-      <policy>system_audit_ssh.yml</policy>
-      <policy>system_audit_pw.yml</policy>
+      <policy>cis_debian9_L1.yml</policy>
+      <policy>cis_debian9_L2.yml</policy>
+      <policy>sca_unix_audit.yml.disabled</policy>
     </policies>
   </sca>
   <wodle name="vulnerability-detector">

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -317,7 +317,7 @@ describe('Rules', function() {
 
         it('Filters: nist-800-53', function(done) {
             request(common.url)
-            .get("/rules?nist-800-53=AU.1")
+            .get("/rules?nist-800-53=AU.14")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)

--- a/test/test_sca.js
+++ b/test/test_sca.js
@@ -17,8 +17,6 @@ var common = require('./common.js');
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 
-
-
 describe('SecurityConfigurationAssessment', function() {
 
     ca_fields = ['score', 'policy_id', 'references', 'name',
@@ -215,7 +213,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Request', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh")
+            .get("/sca/000/checks/unix_audit")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -234,7 +232,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Pagination', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh?offset=0&limit=1")
+            .get("/sca/000/checks/unix_audit?offset=0&limit=1")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -253,7 +251,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Retrieve all elements with limit=0', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh?limit=0")
+            .get("/sca/000/checks/unix_audit?limit=0")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -268,7 +266,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Sort', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh?sort=-")
+            .get("/sca/000/checks/unix_audit?sort=-")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -287,7 +285,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Search', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh?search=2")
+            .get("/sca/000/checks/unix_audit?search=2")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -306,7 +304,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Params: Bad agent id', function(done) {
             request(common.url)
-            .get("/sca/abc/checks/system_audit_ssh")
+            .get("/sca/abc/checks/unix_audit")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(400)
@@ -321,7 +319,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Errors: No agent', function(done) {
             request(common.url)
-            .get("/sca/9999999/checks/system_audit_ssh")
+            .get("/sca/9999999/checks/unix_audit")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -355,7 +353,7 @@ describe('SecurityConfigurationAssessment', function() {
 
         it('Retrieve all elements with limit=0', function(done) {
             request(common.url)
-            .get("/sca/000/checks/system_audit_ssh?limit=0")
+            .get("/sca/000/checks/unix_audit?limit=0")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)


### PR DESCRIPTION
Hi team,

This PR closes #435. I updated mocha tests for last changes introduced in `SCA` and `rules`:

```javascript
# mocha test/test_rules.js 


  Rules
    GET/rules
      ✓ Request (513ms)
      ✓ Pagination (512ms)
      ✓ Retrieve all elements with limit=0 (563ms)
      ✓ Sort (672ms)
      ✓ Search (615ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (518ms)
      ✓ Filters: group (632ms)
      ✓ Filters: level (1) (772ms)
      ✓ Filters: level (2) (796ms)
      ✓ Filters: path (1053ms)
      ✓ Filters: file (835ms)
      ✓ Filters: pci (592ms)
      ✓ Filters: gdpr (493ms)
      ✓ Filters: hipaa (719ms)
      ✓ Filters: nist-800-53 (728ms)
      ✓ Filters: gpg13 (551ms)
    GET/rules/groups
      ✓ Request (574ms)
      ✓ Pagination (486ms)
      ✓ Retrieve all elements with limit=0 (510ms)
      ✓ Sort (513ms)
      ✓ Search (489ms)
      ✓ Filters: Invalid filter
    GET/rules/pci
      ✓ Request (498ms)
      ✓ Pagination (501ms)
      ✓ Retrieve all elements with limit=0 (539ms)
      ✓ Sort (510ms)
      ✓ Search (611ms)
      ✓ Filters: Invalid filter
    GET/rules/gdpr
      ✓ Request (580ms)
      ✓ Pagination (546ms)
      ✓ Retrieve all elements with limit=0 (533ms)
      ✓ Sort (493ms)
      ✓ Search (522ms)
      ✓ Filters: Invalid filter
    GET/rules/gpg13
      ✓ Request (500ms)
      ✓ Pagination (491ms)
      ✓ Retrieve all elements with limit=0 (484ms)
      ✓ Sort (500ms)
      ✓ Search (503ms)
      ✓ Filters: Invalid filter
    GET/rules/hipaa
      ✓ Request (498ms)
      ✓ Pagination (542ms)
      ✓ Retrieve all elements with limit=0 (516ms)
      ✓ Sort (506ms)
      ✓ Search (498ms)
      ✓ Filters: Invalid filter
    GET/rules/nist-800-53
      ✓ Request (544ms)
      ✓ Pagination (497ms)
      ✓ Retrieve all elements with limit=0 (490ms)
      ✓ Sort (490ms)
      ✓ Search (502ms)
      ✓ Filters: Invalid filter
    GET/rules/files
      ✓ Request (330ms)
      ✓ Pagination (347ms)
      ✓ Retrieve all elements with limit=0 (323ms)
      ✓ Sort (333ms)
      ✓ Search (325ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: status (331ms)
      ✓ Filters: download (323ms)
    GET/rules/:rule_id
      ✓ Request (486ms)
      ✓ Pagination (479ms)
      ✓ Retrieve all elements with limit=0 (494ms)
      ✓ Sort (474ms)
      ✓ Search (508ms)
      ✓ Filters: Invalid filter
      ✓ Params: Bad rule id
      ✓ Params: No rule (499ms)


  71 passing (31s)

```

```javascript
# mocha test/test_sca.js   


  SecurityConfigurationAssessment
    GET/sca/:agent_id
      ✓ Request (406ms)
      ✓ Pagination (330ms)
      ✓ Retrieve all elements with limit=0 (336ms)
      ✓ Sort (428ms)
      ✓ Search (335ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (344ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: query (454ms)
      ✓ Retrieve all elements with limit=0 (395ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (450ms)
      ✓ Pagination (400ms)
      ✓ Retrieve all elements with limit=0 (332ms)
      ✓ Sort (344ms)
      ✓ Search (340ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (330ms)
      ✓ Check not found (366ms)
      ✓ Retrieve all elements with limit=0 (339ms)


  20 passing (6s)

```

Furthermore, I updated our test environments in order to adapt `ossec.conf` file to new changes.

Below there are the results of the rest of mocha tests:

```javascript
# mocha test/test_active_response.js 


  Active Response
    PUT/active-response/:agent_id
      ✓ Request (404ms)
      ✓ Command not found (329ms)
      ✓ Agent does not exist (326ms)
      ✓ Agent ID not valid


  4 passing (1s)

```

```javascript
# mocha test/test_agents.js --timeout=10000


  Agents
    GET/agents
      ✓ Request (302ms)
      ✓ Pagination (392ms)
      ✓ Retrieve all elements with limit=0 (328ms)
      ✓ Sort (353ms)
      ✓ Wrong Sort (343ms)
      ✓ Search (359ms)
      ✓ Selector (359ms)
      ✓ Not allowed selector (323ms)
      ✓ Version (524ms)
      ✓ Os.platform (379ms)
      ✓ Os.version (341ms)
      ✓ ManagerHost (334ms)
      ✓ Filters: status (320ms)
      ✓ Filters: status 2 (322ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: older_than (324ms)
      ✓ Filters: group (383ms)
      ✓ Select: single field (428ms)
      ✓ Select: multiple fields (463ms)
      ✓ Select: wrong field (409ms)
      ✓ Select: invalid character
      ✓ Filters: query (391ms)
    GET/agents/summary
      ✓ Request (392ms)
    GET/agents/summary/os
      ✓ Request (411ms)
    GET/agents/outdated
      ✓ Request (319ms)
    GET/agents/:agent_id
      ✓ Request (manager) (344ms)
      ✓ Request (agent) (388ms)
      ✓ Selector (477ms)
      ✓ Not allowed selector (352ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (402ms)
      ✓ Select (529ms)
      ✓ Select: wrong field (463ms)
    GET/agents/name/:agent_name
      ✓ Request (422ms)
      ✓ Wrong name (444ms)
      ✓ Selector (365ms)
      ✓ Not allowed selector (362ms)
    GET/agents/:agent_id/key
      ✓ Request (410ms)
      ✓ Params: Bad agent id
      ✓ Errors: No key (340ms)
    PUT/agents/groups/:group_id
      ✓ Request (377ms)
      ✓ Params: Bad group name
      ✓ Params: Group already exists (334ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (327ms)
      ✓ Params: Bad agent name
      ✓ Params: Agent does not exist (446ms)
      ✓ Params: Replace parameter (431ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (356ms)
      ✓ ErrorOnBadGroup (369ms)
      ✓ ErrorOnEmptyConf
      ✓ OnlyAgentConfAllowed (328ms)
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (351ms)
      ✓ TooBigXML
    GET/agents/no_group
      ✓ Request (298ms)
      ✓ Pagination (337ms)
      ✓ Retrieve all elements with limit=0 (333ms)
      ✓ Sort (322ms)
      ✓ Search (319ms)
      ✓ Select (342ms)
      ✓ Wrong select (332ms)
      ✓ Filter: status (330ms)
    GET/agents/groups
      ✓ Request (414ms)
      ✓ Retrieve all elements with limit=0 (410ms)
      ✓ Hash algorithm (363ms)
      ✓ Wrong Hash algorithm (327ms)
    GET/agents/groups/:group_id
      ✓ Request (314ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (317ms)
      ✓ Select (326ms)
      ✓ Filter: status (385ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (351ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (332ms)
    GET/agents/groups/:group_id/files
      ✓ Request (336ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (369ms)
      ✓ Hash algorithm (340ms)
      ✓ Wrong Hash algorithm (342ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (343ms)
      ✓ UsingFormatAgentConfXML (334ms)
      ✓ UsingFormatAgentConfJSON (331ms)
      ✓ UsingFormatRootcheckXML (352ms)
      ✓ UsingFormatRootcheckJSON (346ms)
      ✓ Params: Bad group name
    POST/agents/groups/:group_id/configuration
      ✓ Request (323ms)
      ✓ ErrorOnBadGroup (326ms)
      ✓ ErrorOnEmptyConf
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (335ms)
      ✓ TooBigXML
    DELETE/agents/:agent_id/group
      ✓ Request (317ms)
      ✓ Errors: ID is not present (334ms)
      ✓ Params: Bad agent id
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (301ms)
      ✓ Errors: ID is not present (328ms)
      ✓ Errors: Group is not present (337ms)
      ✓ Params: Bad agent id
      ✓ Params: Bad group id (344ms)
    DELETE/agents/groups/:group_id
      ✓ Request (349ms)
      ✓ Params: Bad group id
    DELETE/agents
      ✓ Request
      ✓ Filter: older_than, status and ids (3896ms)
      ✓ Errors: Get deleted agent (371ms)
      ✓ Filter: older_than (346ms)
    GET/agents/stats/distinct
      ✓ Request (352ms)
      ✓ Pagination (356ms)
      ✓ Retrieve all elements with limit=0 (334ms)
      ✓ Sort (332ms)
      ✓ Search (322ms)
      ✓ Select (363ms)
      ✓ Wrong select (397ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (488ms)
      ✓ Request-Agent-Buffer (466ms)
      ✓ Request-Agent-Labels (368ms)
      ✓ Request-Agent-Internal (333ms)
      ✓ Request-Agentless-Agentless (363ms)
      ✓ Request-Analysis-Global (543ms)
      ✓ Request-Analysis-Active-response (509ms)
      ✓ Request-Analysis-Alerts (400ms)
      ✓ Request-Analysis-Command (570ms)
      ✓ Request-Analysis-Internal (561ms)
      ✓ Request-Auth-Auth (402ms)
      ✓ Request-Com-Active-response (614ms)
      ✓ Request-Com-Internal (569ms)
      ✓ Request-Csyslog-Csyslog (402ms)
      ✓ Request-Integrator-Integration (680ms)
      ✓ Request-Logcollector-Localfile (775ms)
      ✓ Request-Logcollector-Socket (570ms)
      ✓ Request-Logcollector-Internal (545ms)
      ✓ Request-Mail-Global (515ms)
      ✓ Request-Mail-Alerts (524ms)
      ✓ Request-Mail-Internal (533ms)
      ✓ Request-Monitor-Internal (345ms)
      ✓ Request-Request-Remote (353ms)
      ✓ Request-Request-Internal (348ms)
      ✓ Request-Syscheck-Syscheck (395ms)
      ✓ Request-Syscheck-Rootcheck (400ms)
      ✓ Request-Syscheck-Internal (611ms)
      ✓ Request-Wmodules-Wmodules (770ms)
    PUT/agents/restart
      ✓ Request (781ms)
    PUT/agents/:agent_id/restart
      ✓ Request (597ms)
      ✓ Params: Bad agent id
      ✓ Request (341ms)
    POST/agents/restart
      ✓ Request (355ms)
      ✓ Params: A good id and a bad one (381ms)
      ✓ Params: Bad agent id
      ✓ Request (427ms)


  149 passing (58s)

```

```javascript
# mocha test/test_agents_2.js 


  Agents
    PUT/agents/:agent_name
      ✓ Request (363ms)
      ✓ Errors: Name already present (336ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (332ms)
      ✓ Errors: ID is not present (358ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (395ms)
        ✓ Check key (348ms)
        ✓ Errors: Name already present (367ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (360ms)
        ✓ Errors: Duplicated IP (331ms)
      IP
        ✓ Request (321ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (372ms)
        1) Insert agent with force parameter (ID and name already presents)
        ✓ Errors: Name already present (351ms)
        2) Errors: ID already present
        ✓ Errors: Invalid key (370ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (342ms)
        ✓ Errors: Duplicated IP (347ms)
      IP
        ✓ Request (347ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  26 passing (10s)
  2 failing

  1) Agents
       POST/agents/insert
         Any
           Insert agent with force parameter (ID and name already presents):
     Uncaught AssertionError: expected Object { error: 9012, message: 'Duplicated ID' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:485:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

  2) Agents
       POST/agents/insert
         Any
           Errors: ID already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '750',
    key: 'NzUwIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:526:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

```

This errors will be solved when #3527 would be merged.

```javascript
# mocha test/test_app.js 


  App
    Authentication
      ✓ Wrong USER
      ✓ Wrong password
      ✓ Home
    Requests
      ✓ Inexistent request
      ✓ API version


  5 passing (89ms)

```

```javascript
# mocha test/test_cluster.js 


  Cluster
    GET/cluster/nodes
      ✓ Request (379ms)
      ✓ Pagination (332ms)
      ✓ Retrieve all elements with limit=0 (340ms)
      ✓ Sort (330ms)
      ✓ Search (320ms)
      ✓ Filters: type (349ms)
      ✓ Filters: invalid type (326ms)
      ✓ Select (333ms)
      ✓ Select 2 (325ms)
      ✓ Wrong select (351ms)
    GET/cluster/:node_id/stats
      1) Cluster stats
      ✓ Unexisting node stats (318ms)
      ✓ Analysisd stats (341ms)
      ✓ Remoted stats (346ms)
    GET/cluster/nodes/:node_name
      ✓ Request (322ms)
      ✓ Request wrong name (332ms)
    GET/cluster/status
      ✓ Request (338ms)
    GET/cluster/config
      ✓ Request (317ms)
    GET/cluster/healthcheck
      ✓ Request (309ms)
      ✓ Filter: node name (350ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (350ms)
      ✓ Upload ossec.conf (worker) (368ms)
      ✓ Upload new rules (346ms)
      ✓ Upload rules (overwrite=true) (328ms)
      ✓ Upload rules (overwrite=false) (326ms)
      ✓ Upload new decoder (338ms)
      ✓ Upload decoder (overwrite=true) (327ms)
      ✓ Upload decoder (without overwrite parameter) (327ms)
      ✓ Upload new list (319ms)
      ✓ Upload list (overwrite=true) (328ms)
      ✓ Upload list (overwrite=false) (334ms)
      ✓ Upload corrupted ossec.conf (master)
      ✓ Upload corrupted ossec.conf (worker)
      ✓ Upload malformed rules
      ✓ Upload rules to unexisting node (326ms)
      ✓ Upload malformed decoder
      ✓ Upload decoder to unexisting node (320ms)
      ✓ Upload malformed list
      ✓ Upload list to unexisting node (329ms)
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (323ms)
      ✓ Request ossec.conf (worker) (337ms)
      ✓ Request rules (local) (333ms)
      ✓ Request rules (global) (325ms)
      ✓ Request decoders (local) (327ms)
      ✓ Request decoders (global) (329ms)
      ✓ Request lists (327ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (321ms)
      ✓ Request file from unexisting node (338ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (345ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (1084ms)
      ✓ Request validation (worker) (1079ms)
      ✓ Request validation (all nodes) (1291ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (330ms)
      ✓ Request validation (worker) (1094ms)
      ✓ Request validation (all nodes) (1169ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (1129ms)
      ✓ Request validation (worker) (382ms)
      ✓ Request validation (all nodes) (1425ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (383ms)
      ✓ Request validation (worker) (382ms)
      ✓ Request validation (all nodes) (358ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (323ms)
      ✓ Delete decoders (master) (346ms)
      ✓ Delete CDB list (master) (325ms)
      ✓ Delete file with empty path
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (357ms)
      ✓ Request-Analysis-Global (334ms)
      ✓ Request-Analysis-Active-response (343ms)
      ✓ Request-Analysis-Alerts (345ms)
      ✓ Request-Analysis-Command (324ms)
      ✓ Request-Analysis-Internal (335ms)
      ✓ Request-Auth-Auth (327ms)
      ✓ Request-Com-Active-response (340ms)
      ✓ Request-Com-Internal (327ms)
      ✓ Request-Csyslog-Csyslog (330ms)
      ✓ Request-Integrator-Integration (320ms)
      ✓ Request-Logcollector-Localfile (342ms)
      ✓ Request-Logcollector-Socket (335ms)
      ✓ Request-Logcollector-Internal (338ms)
      ✓ Request-Mail-Global (350ms)
      ✓ Request-Mail-Alerts (324ms)
      ✓ Request-Mail-Internal (326ms)
      ✓ Request-Monitor-Internal (329ms)
      ✓ Request-Request-Remote (326ms)
      ✓ Request-Request-Internal (339ms)
      ✓ Request-Syscheck-Syscheck (328ms)
      ✓ Request-Syscheck-Rootcheck (333ms)
      ✓ Request-Syscheck-Internal (321ms)
      ✓ Request-Wmodules-Wmodules (335ms)
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (332ms)
      ✓ Request (master) (384ms)


  96 passing (40s)
  1 failing

  1) Cluster
       GET/cluster/:node_id/stats
         Cluster stats:
     Uncaught AssertionError: expected Object { error: 1308, message: 'Stats file has not been created yet' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_cluster.js:243:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

```
Stats file has not been created yet. This error is normal when the environment is just started.

```javascript
# mocha test/test_decoders.js 


  Decoders
    GET/decoders
      ✓ Request (385ms)
      ✓ Pagination (362ms)
      ✓ Retrieve all elements with limit=0 (388ms)
      ✓ Sort (395ms)
      ✓ Search (371ms)
      ✓ Filters: File (361ms)
      ✓ Filters: Path (354ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/decoders/files
      ✓ Request (347ms)
      ✓ Pagination (392ms)
      ✓ Retrieve all elements with limit=0 (330ms)
      ✓ Sort (343ms)
      ✓ Search (328ms)
    GET/decoders/parents
      ✓ Request (388ms)
      ✓ Pagination (392ms)
      ✓ Retrieve all elements with limit=0 (408ms)
      ✓ Sort (455ms)
      ✓ Search (416ms)
    GET/decoders/:decoder_name
      ✓ Request (428ms)
      ✓ Pagination (364ms)
      ✓ Retrieve all elements with limit=0 (444ms)
      ✓ Sort (525ms)
      ✓ Search (513ms)


  24 passing (9s)

```

```javascript
# mocha test/test_lists.js    


  Lists
    GET/lists
      ✓ Request (369ms)
      ✓ Pagination (333ms)
      ✓ Retrieve all elements with limit=0 (380ms)
      ✓ Sort (343ms)
      ✓ Search (352ms)
      ✓ Filters: Path (401ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/lists/files
      ✓ Request (395ms)
      ✓ Pagination (407ms)
      ✓ Retrieve all elements with limit=0 (414ms)
      ✓ Sort (344ms)
      ✓ Search (344ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field


  15 passing (4s)

```

```javascript
# mocha test/test_manager.js 


  Manager
    GET/manager/status
      ✓ Request (342ms)
    GET/manager/info
      ✓ Request (326ms)
    GET/manager/configuration
      ✓ Request (331ms)
      ✓ Filters: Missing field section
      ✓ Filters: Section (360ms)
      ✓ Errors: Invalid Section (333ms)
      ✓ Filters: Section - field (323ms)
      ✓ Errors: Invalid field (328ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats
      1) Request
      2) Filters: date
      ✓ Filters: Invalid date
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/stats/hourly
      ✓ Request (318ms)
    GET/manager/stats/weekly
      ✓ Request (323ms)
    GET/manager/stats/analysisd
      ✓ Request (325ms)
    GET/manager/stats/remoted
      ✓ Request (318ms)
    GET/manager/logs
      ✓ Request (360ms)
      ✓ Pagination (338ms)
      ✓ Retrieve all elements with limit=0 (346ms)
      ✓ Sort (340ms)
      ✓ SortField (349ms)
      ✓ Search (354ms)
      ✓ Filters: type_log (339ms)
      ✓ Filters: category (344ms)
      ✓ Filters: type_log and category (333ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
    GET/manager/logs/summary
      ✓ Request (337ms)
    POST/manager/files
      ✓ Upload ossec.conf (323ms)
      ✓ Upload ossec.conf (overwrite=false) (336ms)
      ✓ Upload rules (new rule) (328ms)
      ✓ Upload rules (overwrite=true) (362ms)
      ✓ Upload rules (overwrite=false) (339ms)
      ✓ Upload decoder (overwrite=true) (353ms)
      ✓ Upload decoder (without overwrite parameter) (321ms)
      ✓ Upload list (overwrite=true) (332ms)
      ✓ Upload list (without overwrite parameter) (341ms)
      ✓ Upload malformed rule
      ✓ Upload malformed decoder
      ✓ Upload malformed list
      ✓ Upload list with empty path
      ✓ Upload a file with a wrong content type
    GET/manager/files
      ✓ Request ossec.conf (329ms)
      ✓ Request rules (local) (319ms)
      ✓ Request rules (global) (420ms)
      ✓ Request decoders (local) (478ms)
      ✓ Request decoders (global) (568ms)
      ✓ Request lists (417ms)
      ✓ Request wrong path 1
      ✓ Request wrong path 2
      ✓ Request wrong path 3
      ✓ Request unexisting file (534ms)
      ✓ Request file with empty path
      ✓ Request file with validation parameter (true) (479ms)
    DELETE/manager/files
      ✓ Delete rules (471ms)
      ✓ Delete decoders (368ms)
      ✓ Delete CDB list (330ms)
      ✓ Delete file with empty path
    GET/manager/configuration/validation (OK)
      ✓ Request validation  (1037ms)
    GET/manager/configuration/validation (KO)
      ✓ Request validation (472ms)
    GET/manager/config/:component/:configuration
      ✓ Request-Agentless-Agentless (423ms)
      ✓ Request-Analysis-Global (432ms)
      ✓ Request-Analysis-Active-response (402ms)
      ✓ Request-Analysis-Alerts (384ms)
      ✓ Request-Analysis-Command (372ms)
      ✓ Request-Analysis-Internal (345ms)
      ✓ Request-Auth-Auth (348ms)
      ✓ Request-Com-Active-response (338ms)
      ✓ Request-Com-Internal (341ms)
      ✓ Request-Csyslog-Csyslog (331ms)
      ✓ Request-Integrator-Integration (343ms)
      ✓ Request-Logcollector-Localfile (359ms)
      ✓ Request-Logcollector-Socket (363ms)
      ✓ Request-Logcollector-Internal (364ms)
      ✓ Request-Mail-Global (323ms)
      ✓ Request-Mail-Alerts (335ms)
      ✓ Request-Mail-Internal (408ms)
      ✓ Request-Monitor-Internal (333ms)
      ✓ Request-Request-Remote (345ms)
      ✓ Request-Request-Internal (386ms)
      ✓ Request-Syscheck-Syscheck (414ms)
      ✓ Request-Syscheck-Rootcheck (342ms)
      ✓ Request-Syscheck-Internal (329ms)
      ✓ Request-Wmodules-Wmodules (480ms)
    PUT/manager/restart
      ✓ Request (311ms)


  86 passing (28s)
  2 failing

  1) Manager
       GET/manager/stats
         Request:
     Uncaught AssertionError: expected Object { error: 1308, message: 'Stats file has not been created yet' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_manager.js:226:38)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

  2) Manager
       GET/manager/stats
         Filters: date:
     Uncaught AssertionError: expected Object { error: 1308, message: 'Stats file has not been created yet' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_manager.js:246:38)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

```
Stats file has not been created yet. This error is normal when the environment is just started.

```javascript
# mocha test/test_rootcheck.js 


  Rootcheck
    GET/rootcheck/:agent_id/last_scan
      ✓ Request (371ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (326ms)
    DELETE/rootcheck/:agent_id
      ✓ Request (379ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (334ms)
    DELETE/rootcheck
      ✓ Request (578ms)
    PUT/rootcheck/:agent_id
      ✓ Request (345ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (320ms)
    PUT/rootcheck
      ✓ Request (363ms)


  11 passing (3s)

```

```javascript
# mocha test/test_summary.js 


  Summary
    GET/summary/agents
      ✓ Request (357ms)


  1 passing (364ms)

```

```javascript
# mocha test/test_syscheck.js 


  Syscheck
    GET/syscheck/:agent_id
      ✓ Request (411ms)
      ✓ Pagination (334ms)
      ✓ Retrieve all elements with limit=0 (378ms)
      ✓ Sort (377ms)
      ✓ Search (343ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (374ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: file (361ms)
      ✓ Filters: type (363ms)
      ✓ Filters: summary (385ms)
      ✓ Filters: md5 (398ms)
      ✓ Filters: sha1 (448ms)
      ✓ Filters: sha256 (506ms)
      ✓ Filters: hash (609ms)
    GET/syscheck/:agent_id/last_scan
      ✓ Request (348ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (316ms)
    DELETE/syscheck/:agent_id
      ✓ Request (334ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (357ms)
    DELETE/experimental/syscheck
      ✓ Request (812ms)
    PUT/syscheck/:agent_id
      ✓ Request (337ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (335ms)
    PUT/syscheck
      ✓ Request (435ms)


  27 passing (9s)

```

```javascript
# mocha test/test_syscollector.js 


  Syscollector
    GET/syscollector/:agent_id/os
      ✓ Request (357ms)
      ✓ Selector (386ms)
      ✓ Not allowed selector (381ms)
    GET/syscollector/:agent_id/hardware
      ✓ Request (378ms)
      ✓ Selector (574ms)
      ✓ Not allowed selector (497ms)
    GET/syscollector/:agent_id/packages
      ✓ Request (398ms)
      ✓ Selector (419ms)
      ✓ Not allowed selector (439ms)
      ✓ Pagination (354ms)
      ✓ Wrong limit
      ✓ Sort - (355ms)
      ✓ Sort + (382ms)
      ✓ Wrong Sort (324ms)
      ✓ Search (379ms)
      ✓ Filter: vendor (362ms)
      ✓ Filter: name (368ms)
      ✓ Filter: architecture (347ms)
      ✓ Filter: format (355ms)
      ✓ Wrong filter
    GET/experimental/syscollector/packages
      ✓ Request (732ms)
      ✓ Selector (588ms)
      ✓ Not allowed selector (458ms)
      ✓ Pagination (527ms)
      ✓ Wrong limit
      ✓ Sort - (615ms)
      ✓ Sort + (465ms)
      ✓ Wrong Sort (422ms)
      ✓ Search (562ms)
      ✓ Filter: vendor (625ms)
      ✓ Filter: name (574ms)
      ✓ Filter: architecture (503ms)
      ✓ Filter: format (617ms)
      ✓ Wrong filter
    GET/experimental/syscollector/os
      ✓ Request (386ms)
      ✓ Selector (472ms)
      ✓ Not allowed selector (400ms)
      ✓ Pagination (373ms)
      ✓ Wrong limit
      ✓ Search (454ms)
      ✓ Wrong filter
      ✓ Filter: architecture (426ms)
      ✓ Filter: os_name (396ms)
      ✓ Filter: release (449ms)
    GET/experimental/syscollector/hardware
      ✓ Request (381ms)
      ✓ Selector (419ms)
      ✓ Not allowed selector (367ms)
      ✓ Pagination (394ms)
      ✓ Wrong limit
      ✓ Search (403ms)
      ✓ Wrong filter
      ✓ Wrong Sort (366ms)
      ✓ Filter: ram_total (406ms)
      ✓ Filter: cpu_cores (413ms)
      ✓ Filter: cpu_mhz (424ms)
      ✓ Filter: board_serial (442ms)
    GET/experimental/syscollector/processes
      ✓ Request (392ms)
      ✓ Selector (414ms)
      ✓ Not allowed selector (374ms)
      ✓ Pagination (373ms)
      ✓ Wrong limit
      ✓ Search (415ms)
      ✓ Wrong filter
      ✓ Wrong Sort (393ms)
      ✓ Filter: state (398ms)
      ✓ Filter: ppid (366ms)
      ✓ Filter: egroup (392ms)
      ✓ Filter: euser (377ms)
      ✓ Filter: fgroup (390ms)
      ✓ Filter: name (389ms)
      ✓ Filter: nlwp (385ms)
      ✓ Filter: pgrp (404ms)
      ✓ Filter: priority (386ms)
      ✓ Filter: rgroup (411ms)
      ✓ Filter: ruser (381ms)
      ✓ Filter: sgroup (386ms)
      ✓ Filter: suser (400ms)
    GET/experimental/syscollector/ports
      ✓ Request (358ms)
      ✓ Selector (410ms)
      ✓ Not allowed selector (377ms)
      ✓ Pagination (370ms)
      ✓ Wrong limit
      ✓ Search (457ms)
      ✓ Wrong filter
      ✓ Wrong Sort (406ms)
      ✓ Filter: protocol (414ms)
      ✓ Filter: local_ip (485ms)
      ✓ Filter: local_port (519ms)
      ✓ Filter: remote_ip (446ms)
      ✓ Filter: tx_queue (420ms)
      ✓ Filter: state (408ms)
    GET/syscollector/netaddr
      ✓ Request (489ms)
      ✓ Selector (502ms)
      ✓ Not allowed selector (392ms)
      ✓ Pagination (406ms)
      ✓ Wrong limit
      ✓ Search (540ms)
      ✓ Wrong filter
      ✓ Wrong Sort (386ms)
      ✓ Filter: iface (430ms)
      ✓ Filter: proto (650ms)
      ✓ Filter: address (604ms)
      ✓ Filter: broadcast (435ms)
      ✓ Filter: netmask (407ms)
    GET/experimental/syscollector/netproto
      ✓ Request (490ms)
      ✓ Selector (495ms)
      ✓ Not allowed selector (557ms)
      ✓ Pagination (474ms)
      ✓ Wrong limit
      ✓ Search (740ms)
      ✓ Wrong filter
      ✓ Wrong Sort (391ms)
      ✓ Filter: iface (633ms)
      ✓ Filter: type (405ms)
      ✓ Filter: gateway (450ms)
      ✓ Filter: dhcp (431ms)
    GET/experimental/syscollector/netiface
      ✓ Request (381ms)
      ✓ Selector (461ms)
      ✓ Not allowed selector (358ms)
      ✓ Pagination (502ms)
      ✓ Wrong limit
      ✓ Search (455ms)
      ✓ Wrong filter
      ✓ Wrong Sort (376ms)
      ✓ Filter: name (405ms)
      ✓ Filter: type (483ms)
      ✓ Filter: state (397ms)
      ✓ Filter: mtu (433ms)
      ✓ Filter: tx_packets (397ms)
      ✓ Filter: rx_packets (717ms)
      ✓ Filter: tx_bytes (600ms)
      ✓ Filter: rx_bytes (481ms)
      ✓ Filter: tx_errors (401ms)
      ✓ Filter: rx_errors (547ms)
      ✓ Filter: tx_dropped (408ms)
      ✓ Filter: rx_dropped (443ms)
    GET/syscollector/000/processes
      ✓ Request (335ms)
      ✓ Selector (345ms)
      ✓ Not allowed selector (353ms)
      ✓ Pagination (382ms)
      ✓ Wrong limit
      ✓ Search (398ms)
      ✓ Wrong filter
      ✓ Wrong Sort (426ms)
      ✓ Filter: state (547ms)
      ✓ Filter: ppid (376ms)
      ✓ Filter: egroup (350ms)
      ✓ Filter: euser (358ms)
      ✓ Filter: fgroup (329ms)
      ✓ Filter: name (361ms)
      ✓ Filter: nlwp (337ms)
      ✓ Filter: pgrp (362ms)
      ✓ Filter: priority (344ms)
      ✓ Filter: rgroup (360ms)
      ✓ Filter: ruser (338ms)
      ✓ Filter: sgroup (364ms)
      ✓ Filter: suser (363ms)
    GET/syscollector/000/ports
      ✓ Request (358ms)
      ✓ Selector (363ms)
      ✓ Not allowed selector (364ms)
      ✓ Pagination (373ms)
      ✓ Wrong limit
      ✓ Search (344ms)
      ✓ Wrong filter
      ✓ Wrong Sort (353ms)
      ✓ Filter: protocol (344ms)
      ✓ Filter: local_ip (353ms)
      ✓ Filter: local_port (355ms)
      ✓ Filter: remote_ip (334ms)
      ✓ Filter: tx_queue (353ms)
      ✓ Filter: state (336ms)
    GET/syscollector/000/netaddr
      ✓ Request (328ms)
      ✓ Selector (330ms)
      ✓ Not allowed selector (392ms)
      ✓ Pagination (335ms)
      ✓ Wrong limit
      ✓ Search (382ms)
      ✓ Wrong filter
      ✓ Wrong Sort (353ms)
      ✓ Filter: iface (340ms)
      ✓ Filter: proto (342ms)
      ✓ Filter: address (353ms)
      ✓ Filter: broadcast (343ms)
      ✓ Filter: netmask (336ms)
    GET/syscollector/000/netproto
      ✓ Request (314ms)
      ✓ Selector (350ms)
      ✓ Not allowed selector (337ms)
      ✓ Pagination (339ms)
      ✓ Wrong limit
      ✓ Search (365ms)
      ✓ Wrong filter
      ✓ Wrong Sort (323ms)
      ✓ Filter: iface (344ms)
      ✓ Filter: type (339ms)
      ✓ Filter: gateway (340ms)
      ✓ Filter: dhcp (349ms)
    GET/syscollector/000/netiface
      ✓ Request (319ms)
      ✓ Selector (344ms)
      ✓ Not allowed selector (352ms)
      ✓ Pagination (340ms)
      ✓ Wrong limit
      ✓ Search (355ms)
      ✓ Wrong filter
      ✓ Wrong Sort (332ms)
      ✓ Filter: name (342ms)
      ✓ Filter: type (358ms)
      ✓ Filter: state (345ms)
      ✓ Filter: mtu (349ms)
      ✓ Filter: tx_packets (351ms)
      ✓ Filter: rx_packets (349ms)
      ✓ Filter: tx_bytes (328ms)
      ✓ Filter: rx_bytes (343ms)
      ✓ Filter: tx_errors (344ms)
      ✓ Filter: rx_errors (326ms)
      ✓ Filter: tx_dropped (349ms)
      ✓ Filter: rx_dropped (340ms)


  216 passing (1m)

```


Best regards,

Demetrio.