### PR TITLE
Fix 'ids' parameter when deleting agents

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -1075,8 +1075,13 @@ router.delete('/', function(req, res) {
     else
         data_request['arguments']['purge'] = false;
 
-    if ('ids' in req.query)
-        data_request['arguments']['list_agent_ids'] = req.query.ids.split(',');
+    if ('ids' in req.query) {
+        if (typeof(req.query.ids) == 'string') {
+            data_request['arguments']['list_agent_ids'] = req.query.ids.split(',');
+        } else {
+            data_request['arguments']['list_agent_ids'] = req.query.ids;
+        }
+    }
 
     if ('older_than' in req.query)
         data_request['arguments']['older_than'] = req.query.older_than;


### PR DESCRIPTION
Hi team,

This PR closes #440. After this fix, it is possible to use many times `ids` parameter when deleting agents:

```bash
# curl -u foo:bar -X DELETE "localhost:55000/agents?ids=001&ids=002&ids=003&older_than=1s&pretty" 
{
   "error": 0,
   "data": {
      "msg": "All selected agents were removed",
      "affected_agents": [
         "001",
         "002",
         "003"
      ],
      "older_than": "1s",
      "total_affected_agents": 3
   }
}

```

```bash
# curl -u foo:bar -X DELETE "localhost:55000/agents?ids=010&ids=011&ids=012&pretty"
{
   "error": 0,
   "data": {
      "msg": "Some agents were not removed",
      "affected_agents": [],
      "failed_ids": [
         {
            "id": "010",
            "error": {
               "message": "Agent does not exist: 010",
               "code": 1701
            }
         },
         {
            "id": "011",
            "error": {
               "message": "Agent does not exist: 011",
               "code": 1701
            }
         },
         {
            "id": "012",
            "error": {
               "message": "Agent does not exist: 012",
               "code": 1701
            }
         }
      ],
      "older_than": "7d",
      "total_affected_agents": 0,
      "total_failed_ids": 3
   }
}

```


`Mocha` tests are OK:
```javascript
# mocha test/test_agents.js --timeout=10000


  Agents
    GET/agents
      ✓ Request (318ms)
      ✓ Pagination (353ms)
      ✓ Retrieve all elements with limit=0 (320ms)
      ✓ Sort (325ms)
      ✓ Wrong Sort (316ms)
      ✓ Search (312ms)
      ✓ Selector (328ms)
      ✓ Not allowed selector (311ms)
      ✓ Version (325ms)
      ✓ Os.platform (308ms)
      ✓ Os.version (321ms)
      ✓ ManagerHost (309ms)
      ✓ Filters: status (316ms)
      ✓ Filters: status 2 (309ms)
      ✓ Filters: Invalid filter
      ✓ Filters: Invalid filter - Extra field
      ✓ Filters: older_than (315ms)
      ✓ Filters: group (388ms)
      ✓ Select: single field (366ms)
      ✓ Select: multiple fields (427ms)
      ✓ Select: wrong field (483ms)
      ✓ Select: invalid character
      ✓ Filters: query (448ms)
    GET/agents/summary
      ✓ Request (316ms)
    GET/agents/summary/os
      ✓ Request (443ms)
    GET/agents/outdated
      ✓ Request (305ms)
    GET/agents/:agent_id
      ✓ Request (manager) (321ms)
      ✓ Request (agent) (341ms)
      ✓ Selector (335ms)
      ✓ Not allowed selector (390ms)
      ✓ Params: Bad agent id
      ✓ Errors: No agent (322ms)
      ✓ Select (462ms)
      ✓ Select: wrong field (497ms)
    GET/agents/name/:agent_name
      ✓ Request (350ms)
      ✓ Wrong name (405ms)
      ✓ Selector (368ms)
      ✓ Not allowed selector (316ms)
    GET/agents/:agent_id/key
      ✓ Request (566ms)
      ✓ Params: Bad agent id
      ✓ Errors: No key (516ms)
    PUT/agents/groups/:group_id
      ✓ Request (327ms)
      ✓ Params: Bad group name
      ✓ Params: Group already exists (376ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (477ms)
      ✓ Params: Bad agent name
      ✓ Params: Agent does not exist (487ms)
      ✓ Params: Replace parameter (432ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (443ms)
      ✓ ErrorOnBadGroup (388ms)
      ✓ ErrorOnEmptyConf
      ✓ OnlyAgentConfAllowed (338ms)
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (361ms)
      ✓ TooBigXML
    GET/agents/no_group
      ✓ Request (385ms)
      ✓ Pagination (338ms)
      ✓ Retrieve all elements with limit=0 (333ms)
      ✓ Sort (386ms)
      ✓ Search (329ms)
      ✓ Select (378ms)
      ✓ Wrong select (518ms)
      ✓ Filter: status (486ms)
    GET/agents/groups
      ✓ Request (343ms)
      ✓ Retrieve all elements with limit=0 (347ms)
      ✓ Hash algorithm (391ms)
      ✓ Wrong Hash algorithm (407ms)
    GET/agents/groups/:group_id
      ✓ Request (314ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (353ms)
      ✓ Select (315ms)
      ✓ Filter: status (321ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (309ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (505ms)
    GET/agents/groups/:group_id/files
      ✓ Request (386ms)
      ✓ Params: Bad group name
      ✓ Retrieve all elements with limit=0 (349ms)
      ✓ Hash algorithm (425ms)
      ✓ Wrong Hash algorithm (378ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (332ms)
      ✓ UsingFormatAgentConfXML (353ms)
      ✓ UsingFormatAgentConfJSON (351ms)
      ✓ UsingFormatRootcheckXML (332ms)
      ✓ UsingFormatRootcheckJSON (342ms)
      ✓ Params: Bad group name
    POST/agents/groups/:group_id/configuration
      ✓ Request (340ms)
      ✓ ErrorOnBadGroup (392ms)
      ✓ ErrorOnEmptyConf
      ✓ InvalidConfDetected
      ✓ WrongConfDetected (403ms)
      ✓ TooBigXML
    DELETE/agents/:agent_id/group
      ✓ Request (385ms)
      ✓ Errors: ID is not present (382ms)
      ✓ Params: Bad agent id
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (348ms)
      ✓ Errors: ID is not present (367ms)
      ✓ Errors: Group is not present (365ms)
      ✓ Params: Bad agent id
      ✓ Params: Bad group id (316ms)
    DELETE/agents/groups/:group_id
      ✓ Request (339ms)
      ✓ Params: Bad group id
    DELETE/agents
      ✓ Request
      ✓ Filter: older_than, status and ids (3906ms)
      ✓ Errors: Get deleted agent (361ms)
      ✓ Filter: older_than (440ms)
    GET/agents/stats/distinct
      ✓ Request (455ms)
      ✓ Pagination (449ms)
      ✓ Retrieve all elements with limit=0 (325ms)
      ✓ Sort (357ms)
      ✓ Search (340ms)
      ✓ Select (374ms)
      ✓ Wrong select (363ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (337ms)
      ✓ Request-Agent-Buffer (1381ms)
      ✓ Request-Agent-Labels (671ms)
      ✓ Request-Agent-Internal (393ms)
      ✓ Request-Agentless-Agentless (405ms)
      ✓ Request-Analysis-Global (346ms)
      ✓ Request-Analysis-Active-response (371ms)
      ✓ Request-Analysis-Alerts (304ms)
      ✓ Request-Analysis-Command (306ms)
      ✓ Request-Analysis-Internal (328ms)
      ✓ Request-Auth-Auth (349ms)
      ✓ Request-Com-Active-response (348ms)
      ✓ Request-Com-Internal (371ms)
      ✓ Request-Csyslog-Csyslog (342ms)
      ✓ Request-Integrator-Integration (326ms)
      ✓ Request-Logcollector-Localfile (381ms)
      ✓ Request-Logcollector-Socket (357ms)
      ✓ Request-Logcollector-Internal (317ms)
      ✓ Request-Mail-Global (321ms)
      ✓ Request-Mail-Alerts (338ms)
      ✓ Request-Mail-Internal (374ms)
      ✓ Request-Monitor-Internal (336ms)
      ✓ Request-Request-Remote (335ms)
      ✓ Request-Request-Internal (321ms)
      ✓ Request-Syscheck-Syscheck (346ms)
      ✓ Request-Syscheck-Rootcheck (361ms)
      ✓ Request-Syscheck-Internal (349ms)
      ✓ Request-Wmodules-Wmodules (1392ms)
    PUT/agents/restart
      ✓ Request (363ms)
    PUT/agents/:agent_id/restart
      ✓ Request (367ms)
      ✓ Params: Bad agent id
      ✓ Request (319ms)
    POST/agents/restart
      ✓ Request (328ms)
      ✓ Params: A good id and a bad one (332ms)
      ✓ Params: Bad agent id
      ✓ Request (343ms)


  149 passing (57s)

```

```javascript
# mocha test/test_agents_2.js              


  Agents
    PUT/agents/:agent_name
      ✓ Request (338ms)
      ✓ Errors: Name already present (317ms)
      ✓ Params: Bad agent name
    DELETE/agents/:agent_id
      ✓ Request (326ms)
      ✓ Errors: ID is not present (315ms)
      ✓ Params: Bad agent id
    POST/agents
      Any
        ✓ Request (435ms)
        ✓ Check key (484ms)
        ✓ Errors: Name already present (436ms)
        ✓ Filters: Missing field name
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (385ms)
        ✓ Errors: Duplicated IP (319ms)
      IP
        ✓ Request (325ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2
    POST/agents/insert
      Any
        ✓ Request (354ms)
        1) Insert agent with force parameter (ID and name already presents)
        ✓ Errors: Name already present (320ms)
        2) Errors: ID already present
        ✓ Errors: Invalid key (366ms)
        ✓ Filters: Missing fields
        ✓ Filters: Invalid field
      IP Automatic
        ✓ Request: Automatic IP (530ms)
        ✓ Errors: Duplicated IP (358ms)
      IP
        ✓ Request (338ms)
        ✓ Filters: Bad IP
        ✓ Filters: Bad IP 2


  26 passing (11s)
  2 failing

  1) Agents
       POST/agents/insert
         Any
           Insert agent with force parameter (ID and name already presents):
     Uncaught AssertionError: expected Object { error: 9012, message: 'Duplicated ID' } to have property data
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:485:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

  2) Agents
       POST/agents/insert
         Any
           Errors: ID already present:
     Uncaught AssertionError: expected Object {
  error: 0,
  data: Object {
    id: '750',
    key: 'NzUwIE5ld0FnZW50UG9zdEluc2VydCBhbnkgMWFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGk2NA=='
  }
} to have property message
      at Assertion.fail (node_modules/should/cjs/should.js:258:17)
      at Assertion.value [as properties] (node_modules/should/cjs/should.js:335:19)
      at Test.<anonymous> (test/test_agents_2.js:526:42)
      at Test.assert (node_modules/supertest/lib/test.js:179:6)
      at assert (node_modules/supertest/lib/test.js:131:12)
      at /wazuh-api/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:619:12)
      at /wazuh-api/node_modules/superagent/lib/node/index.js:795:18
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/parsers/json.js:16:7)
      at endReadableNT (_stream_readable.js:1178:12)
      at processTicksAndRejections (internal/process/task_queues.js:77:11)

```

These two errors will be fixed when [#3527](https://github.com/wazuh/wazuh/issues/3527) would be merged.


Best regards,

Demetrio.