### PR TITLE
Fix docstrings for controllers

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -22,7 +22,7 @@ var router = require('express').Router();
  * @apiParam {String} [select] Select which fields to return (separated by comma).
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String="active", "pending", "neverconnected", "disconnected"} [status] Filters by agent status. Use commas to enter multiple statuses.
  * @apiParam {String} [q] Query to filter results by. For example q="status=Active"
  * @apiParam {String} [older_than] Filters out disconnected agents for longer than specified. Time in seconds, '[n_days]d', '[n_hours]h', '[n_minutes]m' or '[n_seconds]s'. For never connected agents, uses the register date.
@@ -417,7 +417,7 @@ router.get('/outdated', cache(), function(req, res) {
  * @apiGroup Info
  *
  * @apiParam {String} agent_name Agent name.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  *
  * @apiDescription Returns various information from an agent called :agent_name.
  *
@@ -455,7 +455,7 @@ router.get('/name/:agent_name', cache(), function(req, res) {
  * @apiGroup Info
  *
  * @apiParam {Number} agent_id Agent ID.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  *
  * @apiDescription Returns various information from an agent.
  *
@@ -840,7 +840,7 @@ router.put('/:agent_id/group/:group_id', function(req, res) {
  * @apiName PostGroupAgents
  * @apiGroup Groups
  *
- * @apiParam {Number} agent_id_list List of agents ID.
+ * @apiParam {String[]} ids List of agents ID.
  * @apiParam {String} group_id Group ID.
  *
  * @apiDescription Adds a list of agents to the specified group.
@@ -853,7 +853,7 @@ router.post('/group/:group_id', function(req, res) {
     logger.debug(req.connection.remoteAddress + " POST /agents/group/:group_id");
 
     var data_request = {'function': 'POST/agents/group/:group_id', 'arguments': {}};
-    var filters = {'group_id':'names', 'ids':'array_numbers'}
+    var filters = {'group_id': 'names', 'ids':'array_numbers'}
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;
@@ -886,11 +886,15 @@ router.delete('/groups', function(req, res) {
 
     var data_request = {'function': 'DELETE/agents/groups', 'arguments': {}};
 
-    if (!filter.check(req.query, {'ids':'array_names'}, req, res))  // Filter with error
+    if (!filter.check(req.query, {'ids': 'array_names'}, req, res))  // Filter with error
         return;
 
     if ('ids' in req.query){
-        data_request['arguments']['group_id'] = req.query.ids.split(',');
+        if (typeof(req.query.ids) == 'string') {
+            data_request['arguments']['group_id'] = req.query.ids.split(',');
+        } else {
+            data_request['arguments']['group_id'] = req.query.ids;
+        }
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
     }else
         res_h.bad_request(req, res, 604, "Missing field: 'ids'");
@@ -984,7 +988,7 @@ router.delete('/:agent_id/group/:group_id', function(req, res) {
  * @apiName DeleteGroupAgents
  * @apiGroup Groups
  *
- * @apiParam {String} agent_id Agent IDs separated by commas.
+ * @apiParam {String} ids Agent IDs separated by commas.
  * @apiParam {String} group_id Group ID.
  *
  * @apiDescription Remove a list of agents of a group
@@ -1006,7 +1010,14 @@ router.delete('/group/:group_id', function(req, res) {
         return;
 
     data_request['arguments']['group_id'] = req.params.group_id;
-    data_request['arguments']['agent_id_list'] = req.query.ids.split(',');
+
+    if ('ids' in req.query) {
+        if (typeof(req.query.ids) == 'string') {
+            data_request['arguments']['agent_id_list'] = req.query.ids.split(',');
+        } else {
+            data_request['arguments']['agent_id_list'] = req.query.ids;
+        }
+    }
 
     if ('ids' in req.query){
         execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
@@ -1230,7 +1241,7 @@ router.post('/insert', function(req, res) {
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
  * @apiParam {String} [fields] List of fields affecting the operation.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [q] Query to filter result. For example q="status=Active"
  *
  * @apiDescription Returns all the different combinations that agents have for the selected fields. It also indicates the total number of agents that have each combination.

--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -680,7 +680,7 @@ router.put('/:agent_id/restart', function(req, res) {
  * @apiParam {Number} agent_id Agent unique ID.
  * @apiParam {String} [wpk_repo] WPK repository.
  * @apiParam {String} [version] Wazuh version.
- * @apiParam {Boolean} [use_http] Use protocol http. If it's false use https. By default the value is set to false.
+ * @apiParam {Boolean} [use_http] Use protocol HTTP. If it is false use HTTPS. By default the value is set to false.
  * @apiParam {number="0","1"} [force] Force upgrade.
  *
  * @apiDescription Upgrade the agent using a WPK file from online repository.
@@ -853,7 +853,7 @@ router.post('/group/:group_id', function(req, res) {
     logger.debug(req.connection.remoteAddress + " POST /agents/group/:group_id");
 
     var data_request = {'function': 'POST/agents/group/:group_id', 'arguments': {}};
-    var filters = {'group_id': 'names', 'ids':'array_numbers'}
+    var filters = {'group_id': 'names', 'ids': 'array_numbers'}
 
     if (!filter.check(req.params, filters, req, res))  // Filter with error
         return;

--- a/controllers/ciscat.js
+++ b/controllers/ciscat.js
@@ -23,7 +23,7 @@ var router = require('express').Router();
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [benchmark] Filters by benchmark.
  * @apiParam {String} [profile] Filters by evaluated profile.
  * @apiParam {Number} [pass] Filters by passed checks.

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -537,7 +537,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
  *
  * @apiParam {String} file Input file.
  * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
- * @apiParam {Bolean} overwrite Replaces the existing file. False by default.
+ * @apiParam {Boolean} overwrite Replaces the existing file. False by default.
  *
  * @apiDescription Upload a local file (rules, decoders and lists) in a cluster node
  *

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -41,7 +41,7 @@ router.get('/node', cache(), function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [type] Filters by node type.
  * 
  * @apiDescription Returns the nodes info
@@ -491,7 +491,7 @@ router.get('/:node_id/logs/summary', cache(), function(req, res) {
  * @apiGroup Files
  *
  * @apiParam {String} path Relative path of file. This parameter is mandatory.
- * @apiParam {String} validation Default false. true for validating the content of the file. An error will be returned file content is not strictly correct.
+ * @apiParam {Boolean} validation Validates the content of the file. An error will be returned if file content is not strictly correct. False by default.
  *
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
@@ -537,7 +537,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
  *
  * @apiParam {String} file Input file.
  * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
- * @apiParam {String} overwrite false to fail if file already exists (default). true to replace the existing file
+ * @apiParam {Bolean} overwrite Replace the existing file. False by default.
  *
  * @apiDescription Upload a local file (rules, decoders and lists) in a cluster node
  *

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -537,7 +537,7 @@ router.get('/:node_id/files', cache(), function(req, res) {
  *
  * @apiParam {String} file Input file.
  * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
- * @apiParam {Bolean} overwrite Replace the existing file. False by default.
+ * @apiParam {Bolean} overwrite Replaces the existing file. False by default.
  *
  * @apiDescription Upload a local file (rules, decoders and lists) in a cluster node
  *

--- a/controllers/decoders.js
+++ b/controllers/decoders.js
@@ -134,7 +134,7 @@ router.get('/parents', cache(), function(req, res) {
     req.apicacheGroup = "decoders";
 
     var data_request = {'function': '/decoders', 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search': 'search_param'};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort': 'sort_param', 'search': 'search_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;

--- a/controllers/decoders.js
+++ b/controllers/decoders.js
@@ -72,7 +72,7 @@ router.get('/', cache(), function(req, res) {
  * @apiParam {String="enabled","disabled", "all"} [status] Filters the decoders by status.
  * @apiParam {String} [file] Filters by filename.
  * @apiParam {String} [path] Filters by path.
- * @apiParam {String} [download] Downloads the file
+ * @apiParam {String} [download] Name of the decoder file to download.
  *
  * @apiDescription Returns all decoders files included in ossec.conf.
  *
@@ -134,7 +134,7 @@ router.get('/parents', cache(), function(req, res) {
     req.apicacheGroup = "decoders";
 
     var data_request = {'function': '/decoders', 'arguments': {}};
-    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search': 'search_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error
         return;

--- a/controllers/experimental.js
+++ b/controllers/experimental.js
@@ -26,7 +26,7 @@ var router = require('express').Router();
  * @apiParam {String} [name] Filters by name.
  * @apiParam {String} [architecture] Filters by architecture.
  * @apiParam {String} [format] Filters by format.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [version] Filter by version name.
  *
  * @apiDescription Returns the agent's packages info
@@ -91,7 +91,7 @@ router.get('/syscollector/packages', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [os_name] Filters by os_name.
  * @apiParam {String} [architecture] Filters by architecture.
  * @apiParam {String} [os_version] Filters by os_version.
@@ -161,7 +161,7 @@ router.get('/syscollector/os', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [ram_free] Filters by ram_free.
  * @apiParam {String} [ram_total] Filters by ram_total.
  * @apiParam {String} [cpu_cores] Filters by cpu_cores.
@@ -233,7 +233,7 @@ router.get('/syscollector/hardware', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {Number} [pid] Filters by process pid.
  * @apiParam {String} [state] Filters by process state.
  * @apiParam {Number} [ppid] Filters by process parent pid.
@@ -329,7 +329,7 @@ router.get('/syscollector/processes', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {Number} [pid] Filters by pid.
  * @apiParam {String} [protocol] Filters by protocol.
  * @apiParam {String} [local_ip] Filters by local_ip.
@@ -404,7 +404,7 @@ router.get('/syscollector/ports', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [proto] Filters by proto.
  * @apiParam {String} [address] Filters by address.
  * @apiParam {String} [broadcast] Filters by broadcast.
@@ -464,7 +464,7 @@ router.get('/syscollector/netaddr', function (req, res) {
  * @apiParam {Number} [offset] First element to return in the collection.
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [search] Looks for elements with the specified string.
  * @apiParam {String} [iface] Filters by iface.
  * @apiParam {String} [type] Filters by type.
@@ -524,7 +524,7 @@ router.get('/syscollector/netproto', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [name] Filters by name.
  * @apiParam {String} [adapter] Filters by adapter.
  * @apiParam {String} [type] Filters by type.
@@ -615,7 +615,7 @@ router.get('/syscollector/netiface', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [benchmark] Filters by benchmark.
  * @apiParam {String} [profile] Filters by evaluated profile.
  * @apiParam {Number} [pass] Filters by passed checks.

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -391,7 +391,7 @@ router.delete('/files', cache(), function(req, res) {
  *
  * @apiParam {String} file Input file.
  * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
- * @apiParam {String} overwrite false to fail if file already exists (default). true to replace the existing file
+ * @apiParam {String} overwrite Replaces the existing file. False by default.
  *
  * @apiDescription Upload a local file (rules, decoders and lists).
  *

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -316,7 +316,7 @@ router.get('/stats/remoted', cache(), function(req, res) {
  * @apiGroup Files
  *
  * @apiParam {String} path Relative path of file. This parameter is mandatory.
- * @apiParam {String} validation Validates the content of the file. An error will be returned if file content is not strictly correct. False by default.
+ * @apiParam {Boolean} validation Validates the content of the file. An error will be returned if file content is not strictly correct. False by default.
  *
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *
@@ -391,7 +391,7 @@ router.delete('/files', cache(), function(req, res) {
  *
  * @apiParam {String} file Input file.
  * @apiParam {String} path Relative path were input file will be placed. This parameter is mandatory.
- * @apiParam {String} overwrite Replaces the existing file. False by default.
+ * @apiParam {Boolean} overwrite Replaces the existing file. False by default.
  *
  * @apiDescription Upload a local file (rules, decoders and lists).
  *

--- a/controllers/manager.js
+++ b/controllers/manager.js
@@ -316,7 +316,7 @@ router.get('/stats/remoted', cache(), function(req, res) {
  * @apiGroup Files
  *
  * @apiParam {String} path Relative path of file. This parameter is mandatory.
- * @apiParam {String} validation Default false. true for validating the content of the file. An error will be returned file content is not strictly correct.
+ * @apiParam {String} validation Validates the content of the file. An error will be returned if file content is not strictly correct. False by default.
  *
  * @apiDescription Returns the content of a local file (rules, decoders and lists).
  *

--- a/controllers/syscheck.js
+++ b/controllers/syscheck.js
@@ -26,7 +26,7 @@ var router = require('express').Router();
  * @apiParam {String} [file] Filters file by filename.
  * @apiParam {String="file","registry"} [type] Selects type of file.
  * @apiParam {String="yes", "no"} [summary] Returns a summary grouping by filename.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [md5] Returns the files with the specified md5 hash.
  * @apiParam {String} [sha1] Returns the files with the specified sha1 hash.
  * @apiParam {String} [sha256] Returns the files with the specified sha256 hash.

--- a/controllers/syscollector.js
+++ b/controllers/syscollector.js
@@ -19,7 +19,7 @@ var router = require('express').Router();
  * @apiGroup OS
  *
  * @apiParam {Number} agent_id Agent ID.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  *
  * @apiDescription Returns the agent's OS info
  *
@@ -53,7 +53,7 @@ router.get('/:agent_id/os', function(req, res) {
  * @apiGroup Hardware
  *
  * @apiParam {Number} agent_id Agent ID.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  *
  * @apiDescription Returns the agent's hardware info
  *
@@ -95,7 +95,7 @@ router.get('/:agent_id/hardware', function(req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [vendor] Filters by vendor.
  * @apiParam {String} [name] Filters by name.
  * @apiParam {String} [architecture] Filters by architecture.
@@ -160,7 +160,7 @@ router.get('/:agent_id/packages', function(req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {Number} [pid] Filters by process pid.
  * @apiParam {String} [state] Filters by process state.
  * @apiParam {Number} [ppid] Filters by process parent pid.
@@ -261,7 +261,7 @@ router.get('/:agent_id/processes', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {Number} [pid] Filters by pid.
  * @apiParam {String} [protocol] Filters by protocol.
  * @apiParam {String} [local_ip] Filters by local_ip.
@@ -340,7 +340,7 @@ router.get('/:agent_id/ports', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [iface] Filters by interface name.
  * @apiParam {String} [proto] Filters by proto.
  * @apiParam {String} [address] Filters by address.
@@ -407,7 +407,7 @@ router.get('/:agent_id/netaddr', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [iface] Filters by iface.
  * @apiParam {String} [type] Filters by type.
  * @apiParam {String} [gateway] Filters by gateway.
@@ -471,7 +471,7 @@ router.get('/:agent_id/netproto', function (req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
- * @apiParam {String} [select] List of selected fields.
+ * @apiParam {String} [select] List of selected fields separated by commas.
  * @apiParam {String} [name] Filters by name.
  * @apiParam {String} [adapter] Filters by adapter.
  * @apiParam {String} [type] Filters by type.


### PR DESCRIPTION
Hi team,

This PR closes #443. Some docstrings were fixed in order to generate the API documentation for `3.10` version.

`ids` parameters were fixed as we did in #441.

Best regards,

Demetrio.