### PR TITLE
Add 'condition' field to 'sca/:agent_id/checks/:policy_id' endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Improvements in the security of the API. `HTTPS` is enabled by default ([#442](https://github.com/wazuh/wazuh-api/pull/442)).
 
+### Changed
+- Now endpoint `GET /sca/:agent_id/checks/:policy_id` shows `condition` fields and can be used to filter by ([#4012](https://github.com/wazuh/wazuh/issues/4012))
+
+
 ## [v3.11.0]
 
 ## Added

--- a/controllers/security_configuration_assessment.js
+++ b/controllers/security_configuration_assessment.js
@@ -34,8 +34,8 @@ var router = require('express').Router();
  *
  */
 router.get('/:agent_id', cache(), function(req, res) {
-    query_checks = {'name':'alphanumeric_param', 'description':'alphanumeric_param', 'references':'alphanumeric_param'};
-    templates.array_request("/sca/:agent_id", req, res, "sca", {'agent_id':'numbers'}, query_checks);
+    query_checks = {'name':'alphanumeric_param', 'description': 'alphanumeric_param', 'references': 'encoded_uri'};
+    templates.array_request("/sca/:agent_id", req, res, "sca", {'agent_id': 'numbers'}, query_checks);
 })
 
 
@@ -72,7 +72,7 @@ router.get('/:agent_id/checks/:policy_id', cache(), function(req, res) {
     query_checks = {'title': 'alphanumeric_param', 'description': 'alphanumeric_param',
         'rationale': 'alphanumeric_param', 'remediation': 'alphanumeric_param',
         'file': 'paths', 'process': 'alphanumeric_param', 'directory': 'paths',
-        'registry': 'alphanumeric_param', 'references': 'alphanumeric_param',
+        'registry': 'alphanumeric_param', 'references': 'encoded_uri',
         'result': 'alphanumeric_param', 'condition': 'alphanumeric_param'
     };
     templates.array_request("/sca/:agent_id/checks/:policy_id", req, res,

--- a/controllers/security_configuration_assessment.js
+++ b/controllers/security_configuration_assessment.js
@@ -30,7 +30,7 @@ var router = require('express').Router();
  * @apiDescription Returns the sca database of an agent.
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/sca/000?q=pass>20;score<150&pretty&limit=2"
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/sca/000?q=pass>2;score<150&pretty&limit=2"
  *
  */
 router.get('/:agent_id', cache(), function(req, res) {
@@ -65,7 +65,7 @@ router.get('/:agent_id', cache(), function(req, res) {
  * @apiDescription Returns the sca checks of an agent.
  *
  * @apiExample {curl} Example usage:
- *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/sca/000/checks/system_audit?pretty"
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/sca/000/checks/unix_audit?limit=1&pretty"
  *
  */
 router.get('/:agent_id/checks/:policy_id', cache(), function(req, res) {

--- a/controllers/security_configuration_assessment.js
+++ b/controllers/security_configuration_assessment.js
@@ -56,6 +56,7 @@ router.get('/:agent_id', cache(), function(req, res) {
  * @apiParam {String} [registry] Filters by registry
  * @apiParam {String} [references] Filters by references
  * @apiParam {String} [result] Filters by result
+ * @apiParam {String} [condition] Filters by condition
  * @apiParam {Number} [offset] First element to return in the collection.
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
@@ -69,8 +70,10 @@ router.get('/:agent_id', cache(), function(req, res) {
  */
 router.get('/:agent_id/checks/:policy_id', cache(), function(req, res) {
     query_checks = {'title': 'alphanumeric_param', 'description': 'alphanumeric_param',
-        'rationale': 'alphanumeric_param', 'remediation': 'alphanumeric_param', 'file': 'paths', 'process': 'alphanumeric_param',
-        'directory': 'paths', 'registry': 'alphanumeric_param', 'references': 'alphanumeric_param', 'result': 'alphanumeric_param'
+        'rationale': 'alphanumeric_param', 'remediation': 'alphanumeric_param',
+        'file': 'paths', 'process': 'alphanumeric_param', 'directory': 'paths',
+        'registry': 'alphanumeric_param', 'references': 'alphanumeric_param',
+        'result': 'alphanumeric_param', 'condition': 'alphanumeric_param'
     };
     templates.array_request("/sca/:agent_id/checks/:policy_id", req, res,
                "sca",

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -97,5 +97,5 @@ exports.format = function(q) {
 }
 
 exports.encoded_uri = function(e) {
-    return input_val(e, /^[a-zA-Z0-9_,\-\.\+\s\:@<>]+$/)
+    return input_val(e, /^[a-zA-Z0-9_,\-\.\+\s\:@<>\/]+$/)
 }

--- a/test/test_sca.js
+++ b/test/test_sca.js
@@ -187,8 +187,46 @@ describe('SecurityConfigurationAssessment', function() {
                 res.body.should.have.properties(['error', 'data']);
 
                 res.body.error.should.equal(0);
-                res.body.data.totalItems.should.be.integer;;
+                res.body.data.totalItems.should.be.integer;
                 res.body.data.items.should.be.instanceof(Array);
+                done();
+            });
+        });
+
+        it('Filters: name', function(done) {
+            request(common.url)
+            .get("/sca/000?name=System%20audit%20for%20Unix%20based%20systems&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.integer;
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(ca_fields);
+                done();
+            });
+        });
+
+        it('Filters: references', function(done) {
+            request(common.url)
+            .get("/sca/000?references=https://www.ssh.com/ssh/&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.integer;
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(ca_fields);
                 done();
             });
         });
@@ -210,6 +248,10 @@ describe('SecurityConfigurationAssessment', function() {
     });  // GET/sca/:agent_id
 
     describe('GET/sca/:agent_id/checks/:policy_id', function() {
+
+        sca_check_fields = ['condition', 'status', 'remediation', 'result',
+                            'rationale', 'policy_id', 'title', 'id',
+                            'reason', 'description', 'compliance', 'rules']
 
         it('Request', function(done) {
             request(common.url)
@@ -364,6 +406,132 @@ describe('SecurityConfigurationAssessment', function() {
                 res.body.error.should.equal(1406);
                 done();
             });
+        });
+
+        it('Filters: description', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?description=Turn%20on%20the%20auditd%20daemon%20to%20record%20system%20events.&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: remediation', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?remediation=Change%20the%20Port%20option%20value%20in%20the%20sshd_config%20file.&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: file', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?file=/etc/ssh/sshd_config&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: references', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?references=https://www.thegeekdiary.com/understanding-etclogin-defs-file&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: result', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?result=failed&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: condition', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?condition=all&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
         });
 
     });  // GET/sca/:agent_id/pci


### PR DESCRIPTION
Hi team,

This PR adds the `condition` field to `/sca/:agent_id/checks/:policy_id` endpoint. I added new Mocha tests for filters in `SCA` endpoints too.

Mocha tests are working fine:
```javascript
# mocha test/test_sca.js 


  SecurityConfigurationAssessment
    GET/sca/:agent_id
      ✓ Request (544ms)
      ✓ Pagination (422ms)
      ✓ Retrieve all elements with limit=0 (474ms)
      ✓ Sort (418ms)
      ✓ Search (433ms)
      ✓ Params: Bad agent id (99ms)
      ✓ Errors: No agent (820ms)
      ✓ Filters: Invalid filter (119ms)
      ✓ Filters: Invalid filter - Extra field (109ms)
      ✓ Filters: query (478ms)
      ✓ Filters: name (452ms)
      ✓ Filters: references (416ms)
      ✓ Retrieve all elements with limit=0 (394ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (422ms)
      ✓ Pagination (430ms)
      ✓ Retrieve all elements with limit=0 (452ms)
      ✓ Sort (419ms)
      ✓ Search (622ms)
      ✓ Params: Bad agent id (124ms)
      ✓ Errors: No agent (525ms)
      ✓ Check not found (565ms)
      ✓ Retrieve all elements with limit=0 (492ms)
      ✓ Filters: description (464ms)
      ✓ Filters: remediation (409ms)
      ✓ Filters: file (419ms)
      ✓ Filters: references (437ms)
      ✓ Filters: result (410ms)
      ✓ Filters: condition (413ms)


  28 passing (12s)

```

Best regards,

Demetrio.