### PR TITLE
Fix for restarting API service after enabling HTTPS.

### DIFF
--- a/install_api.sh
+++ b/install_api.sh
@@ -434,6 +434,13 @@ setup_api() {
     exec_cmd "chown ossec:ossec $APILOG_DIR"
     exec_cmd "chmod 750 $APILOG_DIR"
 
+    # HTTPS never will be enabled if update=yes
+    if [ "X${update}" = "Xno" ]; then
+        if !([ "X${DISABLE_HTTPS}" = "Xy" ] || [ "X${DISABLE_HTTPS}" = "XY" ]); then
+            # enable HTTPS
+            configure_https
+        fi
+    fi
 
     if [ -z "$NO_SERVICE" ]
     then
@@ -443,14 +450,6 @@ setup_api() {
         echo "----------------------------------------------------------------"
     else
         print "\nSkipping service installation."
-    fi
-
-    # HTTPS never will be enabled if update=yes
-    if [ "X${update}" = "Xno" ]; then
-        if !([ "X${DISABLE_HTTPS}" = "Xy" ] || [ "X${DISABLE_HTTPS}" = "XY" ]); then
-            # enable HTTPS
-            configure_https
-        fi
     fi
 
 }


### PR DESCRIPTION
Hi team,

This PR fixes #454. API daemon is enabled after configuring `HTTPS`. It is not needed restarting API after installation after this fix.

```
# ./install_api.sh 
### Wazuh API ###

Installing Wazuh API 3.12.0 from current directory.

Installing API ['/var/ossec/api'].

Installing NodeJS modules.

Generating RSA private key, 4096 bit long modulus
.............................................................................................................................++
.............................................................................................................................++
e is 65537 (0x10001)
writing RSA key
HTTPS enabled.

Key: /var/ossec/api/configuration/ssl/server.key.
Certificate: /var/ossec/api/configuration/ssl/server.crt


Installing service.
----------------------------------------------------------------
Installing for systemd
----------------------------------------------------------------

API URL: https://host_ip:55000/
user: 'foo'
password: 'bar'
Configuration: /var/ossec/api/configuration
Test: curl -u foo:bar -k https://127.0.0.1:55000?pretty
Note: You can configure the API executing /var/ossec/api/scripts/configure_api.sh

### [API installed successfully] ###
[root@wazuh-master wazuh-api]# curl -u foo:bar -k https://127.0.0.1:55000?pretty
{
   "error": 0,
   "data": {
      "msg": "Welcome to Wazuh HIDS API",
      "api_version": "v3.12.0",
      "hostname": "wazuh-master",
      "timestamp": "Mon Oct 21 2019 06:44:11 GMT+0000 (UTC)"
   }
}
```

Best regards,

Demetrio.