### PR TITLE
Fix link to API installation guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Wazuh API capabilities:
 
 #### How to install
 
-[Installation guide](https://documentation.wazuh.com/current/installation-guide/installing-wazuh-server/index.html)
+[Installation guide](https://documentation.wazuh.com/current/installation-guide/installing-wazuh-manager/index.html)
 
 #### Request reference
 


### PR DESCRIPTION
Hello team, I've detected a broken URL to the documentation in our README.  This PR fix it. 