### PR TITLE
Add 'mitre' filter for rules

### DIFF
--- a/controllers/rules.js
+++ b/controllers/rules.js
@@ -31,6 +31,7 @@ var router = require('express').Router();
  * @apiParam {String} [hipaa] Filters the rules by hipaa requirement.
  * @apiParam {String} [nist-800-53] Filters the rules by nist-800-53 requirement.
  * @apiParam {String} [gpg13] Filters the rules by gpg13 requirement.
+ * @apiParam {String} [mitre] Filters the rules by mitre requirement.
  * @apiParam {String} [q] Query to filter results by. For example q=id=89055
  *
  * @apiDescription Returns all rules.
@@ -44,7 +45,8 @@ router.get('/', cache(), function(req, res) {
     query_checks = {'status':'alphanumeric_param', 'group':'alphanumeric_param',
         'level':'ranges', 'path':'paths', 'file':'alphanumeric_param', 'pci':'alphanumeric_param',
         'gdpr': 'alphanumeric_param', 'hipaa': 'alphanumeric_param',
-        'nist-800-53': 'alphanumeric_param', 'gpg13': 'alphanumeric_param'};
+        'nist-800-53': 'alphanumeric_param', 'gpg13': 'alphanumeric_param',
+        'mitre': 'alphanumeric_param'};
 
     templates.array_request('/rules', req, res, "rules", param_checks, query_checks);
 })
@@ -270,6 +272,46 @@ router.get('/nist-800-53', cache(), function(req, res) {
     req.apicacheGroup = "rules";
 
     var data_request = {'function': '/rules/nist-800-53', 'arguments': {}};
+    var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
+
+    if (!filter.check(req.query, filters, req, res))  // Filter with error
+        return;
+
+    if ('offset' in req.query)
+        data_request['arguments']['offset'] = Number(req.query.offset);
+    if ('limit' in req.query)
+        data_request['arguments']['limit'] = Number(req.query.limit);
+    if ('sort' in req.query)
+        data_request['arguments']['sort'] = filter.sort_param_to_json(req.query.sort);
+    if ('search' in req.query)
+        data_request['arguments']['search'] = filter.search_param_to_json(req.query.search);
+
+    execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
+})
+
+
+/**
+ * @api {get} /rules/mitre Get rule mitre requirements
+ * @apiName GetRulesMitre
+ * @apiGroup Info
+ *
+ * @apiParam {Number} [offset] First element to return in the collection.
+ * @apiParam {Number} [limit=500] Maximum number of elements to return.
+ * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
+ * @apiParam {String} [search] Looks for elements with the specified string.
+ *
+ * @apiDescription Returns the Mitre requirements of all rules.
+ *
+ * @apiExample {curl} Example usage:
+ *     curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/Mitre?offset=0&limit=2&pretty"
+ *
+ */
+router.get('/mitre', cache(), function(req, res) {
+    logger.debug(req.connection.remoteAddress + " GET /rules/mitre");
+
+    req.apicacheGroup = "rules";
+
+    var data_request = {'function': '/rules/mitre', 'arguments': {}};
     var filters = {'offset': 'numbers', 'limit': 'numbers', 'sort':'sort_param', 'search':'search_param'};
 
     if (!filter.check(req.query, filters, req, res))  // Filter with error

--- a/test/test_rules.js
+++ b/test/test_rules.js
@@ -15,7 +15,9 @@ var request = require('supertest');
 var common = require('./common.js');
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-rule_fields = ['status', 'gdpr', 'pci', 'gpg13', 'hipaa', 'nist-800-53','description', 'path', 'file', 'level', 'groups', 'id', 'details']
+rule_fields = ['status', 'gdpr', 'pci', 'gpg13', 'hipaa', 'nist-800-53',
+               'mitre', 'description', 'path', 'file', 'level', 'groups', 'id',
+               'details']
 
 describe('Rules', function() {
 
@@ -337,6 +339,25 @@ describe('Rules', function() {
         it('Filters: gpg13', function(done) {
             request(common.url)
             .get("/rules?gpg13=10.1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array)
+                res.body.data.items[0].should.have.properties(rule_fields);
+                done();
+            });
+        });
+
+        it('Filters: mitre', function(done) {
+            request(common.url)
+            .get("/rules?mitre=T1110")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -1057,6 +1078,116 @@ describe('Rules', function() {
         });
 
     });  // GET/rules/nist-800-53
+
+    describe('GET/rules/mitre', function() {
+
+        it('Request', function(done) {
+            request(common.url)
+            .get("/rules/mitre")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Pagination', function(done) {
+            request(common.url)
+            .get("/rules/mitre?offset=0&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.items.should.be.instanceof(Array).and.have.lengthOf(1);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Retrieve all elements with limit=0', function(done) {
+            request(common.url)
+            .get("/rules/mitre?limit=0")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+                res.body.error.should.equal(1406);
+                done();
+            });
+        });
+
+        it('Sort', function(done) {
+            request(common.url)
+            .get("/rules/mitre?sort=-")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Search', function(done) {
+            request(common.url)
+            .get("/rules/mitre?search=T1110")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.be.string;
+                done();
+            });
+        });
+
+        it('Filters: Invalid filter', function(done) {
+            request(common.url)
+            .get("/rules/mitre?random")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(400)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'message']);
+
+                res.body.error.should.equal(604);
+                done();
+            });
+        });
+
+    });  // GET/rules/mitre
 
     describe('GET/rules/files', function() {
 


### PR DESCRIPTION
Hi team,

This PR adds a new endpoint for filtering rules by Mitre attack IDs.

```javascript
# mocha /wazuh-api/test/test_rules.js 


  Rules
    GET/rules
      ✓ Request (609ms)
      ✓ Pagination (570ms)
      ✓ Retrieve all elements with limit=0 (572ms)
      ✓ Sort (704ms)
      ✓ Search (756ms)
      ✓ Filters: Invalid filter (96ms)
      ✓ Filters: Invalid filter - Extra field (106ms)
      ✓ Filters: status (852ms)
      ✓ Filters: group (708ms)
      ✓ Filters: level (1) (593ms)
      ✓ Filters: level (2) (734ms)
      ✓ Filters: path (589ms)
      ✓ Filters: file (587ms)
      ✓ Filters: pci (794ms)
      ✓ Filters: gdpr (577ms)
      ✓ Filters: hipaa (1130ms)
      ✓ Filters: nist-800-53 (612ms)
      ✓ Filters: gpg13 (602ms)
      ✓ Filters: mitre (789ms)
      ✓ Filters: query 1 (589ms)
      ✓ Filters: query 2 (594ms)
    GET/rules/groups
      ✓ Request (616ms)
      ✓ Pagination (663ms)
      ✓ Retrieve all elements with limit=0 (669ms)
      ✓ Sort (675ms)
      ✓ Search (623ms)
      ✓ Filters: Invalid filter (106ms)
    GET/rules/pci
      ✓ Request (651ms)
      ✓ Pagination (654ms)
      ✓ Retrieve all elements with limit=0 (748ms)
      ✓ Sort (860ms)
      ✓ Search (688ms)
      ✓ Filters: Invalid filter (116ms)
    GET/rules/gdpr
      ✓ Request (906ms)
      ✓ Pagination (567ms)
      ✓ Retrieve all elements with limit=0 (599ms)
      ✓ Sort (850ms)
      ✓ Search (620ms)
      ✓ Filters: Invalid filter (96ms)
    GET/rules/gpg13
      ✓ Request (618ms)
      ✓ Pagination (622ms)
      ✓ Retrieve all elements with limit=0 (596ms)
      ✓ Sort (575ms)
      ✓ Search (594ms)
      ✓ Filters: Invalid filter (97ms)
    GET/rules/hipaa
      ✓ Request (585ms)
      ✓ Pagination (600ms)
      ✓ Retrieve all elements with limit=0 (628ms)
      ✓ Sort (585ms)
      ✓ Search (572ms)
      ✓ Filters: Invalid filter (97ms)
    GET/rules/nist-800-53
      ✓ Request (583ms)
      ✓ Pagination (580ms)
      ✓ Retrieve all elements with limit=0 (604ms)
      ✓ Sort (717ms)
      ✓ Search (743ms)
      ✓ Filters: Invalid filter (112ms)
    GET/rules/mitre
      ✓ Request (854ms)
      ✓ Pagination (597ms)
      ✓ Retrieve all elements with limit=0 (564ms)
      ✓ Sort (589ms)
      ✓ Search (579ms)
      ✓ Filters: Invalid filter (99ms)
    GET/rules/files
      ✓ Request (401ms)
      ✓ Pagination (414ms)
      ✓ Retrieve all elements with limit=0 (402ms)
      ✓ Sort (410ms)
      ✓ Search (403ms)
      ✓ Filters: Invalid filter (98ms)
      ✓ Filters: Invalid filter - Extra field (97ms)
      ✓ Filters: status (419ms)
      ✓ Filters: download (394ms)
    GET/rules/:rule_id
      ✓ Request (616ms)
      ✓ Pagination (561ms)
      ✓ Retrieve all elements with limit=0 (569ms)
      ✓ Sort (562ms)
      ✓ Search (565ms)
      ✓ Filters: Invalid filter (102ms)
      ✓ Params: Bad rule id (98ms)
      ✓ Params: No rule (589ms)


  80 passing (43s)

```

Best regards,

Demetrio.