### PR TITLE
3.12 special character agent name

### DIFF
--- a/helpers/errors.js
+++ b/helpers/errors.js
@@ -22,7 +22,7 @@ errors['100'] = "Unauthorized request. Cluster privileges required";
 // 600 - 699 Requests
 errors['600'] = "Param not valid. Integer expected";  // Integer
 errors['numbers'] = 600;
-errors['601'] = "Param not valid. Valid characters: a-z, A-Z, 0-9, ., _, -";  // Names
+errors['601'] = "Param not valid. Valid characters: a-z, A-Z, 0-9, ., _, -, %";  // Names
 errors['names'] = 601;
 errors['603'] = "The requested URL was not found on this server";  // Default error
 errors['604'] = "Filter error";  // Filter

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -24,7 +24,7 @@ exports.array_numbers = function(n) {
 }
 
 exports.names = function(name) {
-    return input_val(name, /^[a-zA-Z0-9_\-\.]+$/);
+    return input_val(name, /^[a-zA-Z0-9_\-.%]+$/);
 }
 
 exports.array_names = function(names) {

--- a/test/test_agents.js
+++ b/test/test_agents.js
@@ -2106,7 +2106,7 @@ describe('Agents', function() {
                 .expect(200)
                 .end(function (err, res) {
                     if (err) throw err;
-                    agent1_id = res.body.data.id
+                    agent1_id = res.body.data.id;
                     done();
                 });
         });
@@ -2120,7 +2120,7 @@ describe('Agents', function() {
                 .expect(200)
                 .end(function (err, res) {
                     if (err) throw err;
-                    agent2_id = res.body.data.id
+                    agent2_id = res.body.data.id;
                     done();
                 });
         });
@@ -2219,7 +2219,7 @@ describe('Agents', function() {
 
                     res.body.error.should.equal(0);
                     res.body.data.totalItems.should.be.above(0);
-                    res.body.data.items.should.be.instanceof(Array)
+                    res.body.data.items.should.be.instanceof(Array);
                     res.body.data.items[0].should.have.properties(fields);
                     res.body.data.items[0].os.should.have.properties(agent_os_properties);
                     done();
@@ -3094,7 +3094,7 @@ describe('Agents', function() {
                 res.body.error.should.equal(0);
                 res.body.data.should.be.type('object');
                 res.body.data.should.have.properties(['msg', 'affected_agents']);
-                res.body.data.affected_agents.sort().should.be.eql(['001', '002', '003'].sort());
+                res.body.data.affected_agents.sort().should.be.eql(['001', '002'].sort());
                 res.body.data.msg.should.equal('All selected agents were restarted');
                 done();
             });

--- a/test/test_agents_2.js
+++ b/test/test_agents_2.js
@@ -101,7 +101,46 @@ describe('Agents', function() {
             });
         });
 
-    });  // PUT/agents/:agent_name
+        before('Request', function(done) {
+            request(common.url)
+            .put("/agents/testingNewAgent%2520Put")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['id', 'key']);
+
+                res.body.error.should.equal(0);
+                res.body.data.id.should.match(/^\d+$/);
+                res.body.data.key.should.match(/^[a-zA-Z0-9=]+$/);
+                agent_id = res.body.data.id;
+                done();
+            });
+        });
+
+        it('Params: New character (%) in agent name', function(done) {
+            request(common.url)
+            .get("/agents/name/testingNewAgent%2520Put")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+                res.body.data.should.have.properties(['id', 'node_name', 'ip', 'dateAdd', 'status', 'registerIP', 'name']);
+
+                res.body.error.should.equal(0);
+                res.body.data.id.should.match(/^\d+$/);
+                res.body.data.name.should.match(/^[a-zA-Z0-9_\-.%]+$/);
+                agent_id = res.body.data.id;
+                done();
+            });
+        });
+	});  // PUT/agents/:agent_name
 
     describe('DELETE/agents/:agent_id', function() {
         var agent_id = 0;


### PR DESCRIPTION
Hi team,

This PR closes https://github.com/wazuh/wazuh/issues/4184. In this PR, We have added the special character '%' to the agent_name regex. In this way we have made it possible to use it in the name of the agents.

### Mocha tests

We can see that an error happens but this is known and we have an issue of it (https://github.com/wazuh/wazuh/issues/4224). In any case does not affect this new functionality.

```bash
root@8d3bbb4a1e5b:/wazuh-api# mocha test/test_agents.js --timeout 10000


  Agents
    GET/agents
(node:958) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (293ms)
      ✓ Pagination (296ms)
      ✓ Retrieve all elements with limit=0 (279ms)
      ✓ Sort (278ms)
      ✓ Wrong Sort (287ms)
      ✓ Search (295ms)
      ✓ Selector (284ms)
      ✓ Not allowed selector (278ms)
      ✓ Version (277ms)
      ✓ Os.platform (278ms)
      ✓ Os.version (282ms)
      ✓ ManagerHost (285ms)
      ✓ Filters: status (288ms)
      ✓ Filters: status 2 (283ms)
      ✓ Filters: Invalid filter (97ms)
      ✓ Filters: Invalid filter - Extra field (97ms)
      ✓ Filters: older_than (288ms)
      ✓ Filters: group (285ms)
      ✓ Select: single field (275ms)
      ✓ Select: multiple fields (275ms)
      ✓ Select: wrong field (285ms)
      ✓ Select: invalid character (99ms)
      ✓ Filters: query (276ms)
    GET/agents/summary
      ✓ Request (280ms)
    GET/agents/summary/os
      ✓ Request (281ms)
    GET/agents/outdated
      ✓ Request (273ms)
    GET/agents/:agent_id
      ✓ Request (manager) (279ms)
      ✓ Request (agent) (286ms)
      ✓ Selector (283ms)
      ✓ Not allowed selector (276ms)
      ✓ Params: Bad agent id (96ms)
      ✓ Errors: No agent (281ms)
      ✓ Select (277ms)
      ✓ Select: wrong field (283ms)
    GET/agents/name/:agent_name
      ✓ Request (298ms)
      ✓ Wrong name (277ms)
      ✓ Selector (281ms)
      ✓ Not allowed selector (286ms)
    GET/agents/:agent_id/key
      ✓ Request (283ms)
      ✓ Params: Bad agent id (98ms)
      ✓ Errors: No key (276ms)
    PUT/agents/groups/:group_id
      ✓ Request (290ms)
      ✓ Params: Bad group name (99ms)
      ✓ Params: Group already exists (274ms)
    PUT/agents/:agent_id/group/:group_id
      ✓ Request (286ms)
      ✓ Params: Bad agent name (97ms)
      ✓ Params: Agent does not exist (282ms)
      ✓ Params: Replace parameter (278ms)
    POST/agents/groups/:group_id/files/:file_name
      ✓ Request (314ms)
      ✓ ErrorOnBadGroup (283ms)
      ✓ ErrorOnEmptyConf (97ms)
      ✓ OnlyAgentConfAllowed (280ms)
      ✓ InvalidConfDetected (98ms)
      ✓ WrongConfDetected (295ms)
      ✓ TooBigXML (103ms)
    GET/agents/no_group
      ✓ Request (277ms)
      ✓ Pagination (293ms)
      ✓ Retrieve all elements with limit=0 (278ms)
      ✓ Sort (282ms)
      ✓ Search (287ms)
      ✓ Select (276ms)
      ✓ Wrong select (276ms)
      ✓ Filter: status (278ms)
    GET/agents/groups
      ✓ Request (275ms)
      ✓ Retrieve all elements with limit=0 (281ms)
      ✓ Hash algorithm (279ms)
      ✓ Wrong Hash algorithm (286ms)
      ✓ Filters: query 1 (280ms)
      ✓ Filters: query 2 (285ms)
      ✓ Filters: query 3 (293ms)
    GET/agents/groups/:group_id
      ✓ Request (280ms)
      ✓ Params: Bad group name (98ms)
      ✓ Retrieve all elements with limit=0 (278ms)
      ✓ Select (296ms)
      ✓ Filter: status (290ms)
    GET/agents/groups/:group_id/configuration
      ✓ Request (280ms)
      ✓ Params: Bad group name (99ms)
      ✓ Retrieve all elements with limit=0 (297ms)
    GET/agents/groups/:group_id/files
      ✓ Request (284ms)
      ✓ Params: Bad group name (99ms)
      ✓ Retrieve all elements with limit=0 (279ms)
      ✓ Hash algorithm (284ms)
      ✓ Wrong Hash algorithm (277ms)
    GET/agents/groups/:group_id/files/:filename
      ✓ Request (282ms)
      ✓ UsingFormatAgentConfXML (295ms)
      ✓ UsingFormatAgentConfJSON (288ms)
      ✓ UsingFormatRootcheckXML (277ms)
      ✓ UsingFormatRootcheckJSON (284ms)
      ✓ Params: Bad group name (103ms)
    POST/agents/groups/:group_id/configuration
      ✓ Request (297ms)
      ✓ ErrorOnBadGroup (282ms)
      ✓ ErrorOnEmptyConf (99ms)
      ✓ InvalidConfDetected (104ms)
      ✓ WrongConfDetected (299ms)
      ✓ TooBigXML (103ms)
    DELETE/agents/:agent_id/group
      ✓ Request (287ms)
      ✓ Errors: ID is not present (310ms)
      ✓ Params: Bad agent id (98ms)
    DELETE/agents/:agent_id/group/:group_id
      ✓ Request (272ms)
      ✓ Errors: ID is not present (291ms)
      ✓ Errors: Group is not present (300ms)
      ✓ Params: Bad agent id (100ms)
      ✓ Params: Bad group id (277ms)
    DELETE/agents/groups/:group_id
      ✓ Request (279ms)
      ✓ Params: Bad group id (105ms)
    DELETE/agents
      ✓ Request (94ms)
      ✓ Filter: older_than, status and ids (3811ms)
      ✓ Errors: Get deleted agent (321ms)
      ✓ Filter: older_than (303ms)
    GET/agents/stats/distinct
      ✓ Request (293ms)
      ✓ Pagination (282ms)
      ✓ Retrieve all elements with limit=0 (285ms)
      ✓ Sort (286ms)
      ✓ Search (278ms)
      ✓ Select (279ms)
      ✓ Wrong select (283ms)
    GET/agents/:agent/config/:component/:configuration
      ✓ Request-Agent-Client (306ms)
      ✓ Request-Agent-Buffer (285ms)
      ✓ Request-Agent-Labels (295ms)
      ✓ Request-Agent-Internal (307ms)
      ✓ Request-Agentless-Agentless (279ms)
      ✓ Request-Analysis-Global (287ms)
      ✓ Request-Analysis-Active-response (298ms)
      ✓ Request-Analysis-Alerts (284ms)
      ✓ Request-Analysis-Command (280ms)
      ✓ Request-Analysis-Internal (294ms)
      ✓ Request-Auth-Auth (286ms)
      ✓ Request-Com-Active-response (292ms)
      ✓ Request-Com-Internal (289ms)
      ✓ Request-Csyslog-Csyslog (293ms)
      ✓ Request-Integrator-Integration (281ms)
      ✓ Request-Logcollector-Localfile (299ms)
      ✓ Request-Logcollector-Socket (300ms)
      ✓ Request-Logcollector-Internal (294ms)
      ✓ Request-Mail-Global (279ms)
      ✓ Request-Mail-Alerts (319ms)
      ✓ Request-Mail-Internal (300ms)
      ✓ Request-Monitor-Internal (287ms)
      ✓ Request-Request-Remote (282ms)
      ✓ Request-Request-Internal (297ms)
      ✓ Request-Syscheck-Syscheck (300ms)
      ✓ Request-Syscheck-Rootcheck (327ms)
      ✓ Request-Syscheck-Internal (309ms)
      ✓ Request-Wmodules-Wmodules (312ms)
    PUT/agents/restart
      ✓ Request (341ms)
    PUT/agents/:agent_id/restart
      ✓ Request (2592ms)
      ✓ Params: Bad agent id (104ms)
      ✓ Request (307ms)
    POST/agents/restart
      ✓ Request (330ms)
      ✓ Params: A good id and a bad one (340ms)
      ✓ Params: Bad agent id (100ms)
      ✓ Request (292ms)
    PUT/agents/groups/:group_id/restart
      1) Request
      ✓ Params: Bad group id (298ms)
      ✓ Group without agents (286ms)


  154 passing (51s)
  1 failing
```

```bash
root@1c4fd97238ae:/wazuh-api# mocha test/test_agents_2.js --timeout 10000


  Agents
    PUT/agents/:agent_name
(node:977) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (310ms)
      ✓ Errors: Name already present (283ms)
      ✓ Params: Bad agent name (94ms)
    DELETE/agents/:agent_id
      ✓ Request (284ms)
      ✓ Errors: ID is not present (289ms)
      ✓ Params: Bad agent id (96ms)
    POST/agents
      Any
        ✓ Request (330ms)
        ✓ Check key (281ms)
        ✓ Errors: Name already present (281ms)
        ✓ Filters: Missing field name (94ms)
        ✓ Filters: Invalid field (93ms)
      IP Automatic
        ✓ Request: Automatic IP (311ms)
        ✓ Errors: Duplicated IP (285ms)
      IP
        ✓ Request (289ms)
        ✓ Filters: Bad IP (94ms)
        ✓ Filters: Bad IP 2 (95ms)
    POST/agents/insert
      Any
        ✓ Request (323ms)
        ✓ Insert agent with force parameter (ID and name already presents) (321ms)
        ✓ Errors: Name already present (303ms)
        ✓ Errors: ID already present (294ms)
        ✓ Errors: Invalid key (308ms)
        ✓ Filters: Missing fields (99ms)
        ✓ Filters: Invalid field (95ms)
      IP Automatic
        ✓ Request: Automatic IP (288ms)
        ✓ Errors: Duplicated IP (296ms)
      IP
        ✓ Request (281ms)
        ✓ Filters: Bad IP (95ms)
        ✓ Filters: Bad IP 2 (94ms)


  28 passing (10s)
```
