### PR TITLE
Update date filter for syscheck endpoints

### DIFF
--- a/test/test_syscheck.js
+++ b/test/test_syscheck.js
@@ -330,6 +330,60 @@ describe('Syscheck', function() {
             });
         });
 
+        it('Filters: "%Y-%m-%d" date', function(done) {
+            request(common.url)
+            .get("/syscheck/000?q=mtime>2018-01-01")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.an.integer;
+                res.body.data.items.should.be.instanceof(Array)
+                done();
+            });
+        });
+
+        it('Filters: "%Y-%m-%d %H:%M:%S" date', function(done) {
+            request(common.url)
+            .get("/syscheck/000?q=mtime>" + encodeURI("2018-01-01 00:00:00"))
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.an.integer;
+                res.body.data.items.should.be.instanceof(Array)
+                done();
+            });
+        });
+
+        it('Filters: timestamp date', function(done) {
+            request(common.url)
+            .get("/syscheck/000?q=mtime>1514761200")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.an.integer;
+                res.body.data.items.should.be.instanceof(Array)
+                done();
+            });
+        });
+
     });  // GET/syscheck/:agent_id
 
     describe('GET/syscheck/:agent_id/last_scan', function() {


### PR DESCRIPTION
|Related issue|
|#4466|

## Description

This PR fixes date filter for q parameter in `syscheck` endpoints. It adds the option to use `"%Y-%m-%d"` format apart from `timestamp` and `"%Y-%m-%d %H:%M:%S"`

## Tests

Added 3 mocha tests:
```
Syscheck
    GET/syscheck/:agent_id
(node:2286) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (359ms)
      ✓ Pagination (252ms)
      ✓ Retrieve all elements with limit=0 (252ms)
      ✓ Sort (251ms)
      ✓ Search (252ms)
      ✓ Params: Bad agent id (77ms)
      ✓ Errors: No agent (235ms)
      ✓ Filters: Invalid filter (80ms)
      ✓ Filters: Invalid filter - Extra field (78ms)
      ✓ Filters: file (255ms)
      ✓ Filters: type (243ms)
      ✓ Filters: summary (244ms)
      ✓ Filters: md5 (258ms)
      ✓ Filters: sha1 (254ms)
      ✓ Filters: sha256 (254ms)
      ✓ Filters: hash (255ms)
      ✓ Filters: distinct (258ms)
      ✓ Filters: "%Y-%m-%d" date (312ms)
      ✓ Filters: "%Y-%m-%d %H:%M:%S" date (314ms)
      ✓ Filters: timestamp date (314ms)
    GET/syscheck/:agent_id/last_scan
      ✓ Request (256ms)
      ✓ Params: Bad agent id (80ms)
      ✓ Errors: No agent (236ms)
    DELETE/syscheck/:agent_id
      ✓ Request (243ms)
      ✓ Params: Bad agent id (78ms)
      ✓ Errors: No agent (240ms)
    DELETE/experimental/syscheck
      ✓ Request (571ms)
    PUT/syscheck/:agent_id
      ✓ Request (257ms)
      ✓ Params: Bad agent id (82ms)
      ✓ Errors: No agent (254ms)
    PUT/syscheck
      ✓ Request (260ms)


  31 passing (7s)
```