### PR TITLE
Add code-block to example responses in generate_rst.py

### DIFF
--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -390,7 +390,7 @@ if __name__ == "__main__":
                         alerts.append(msg_end + " -> " + output)
 
                     f.write(str_example_res + '\n')
-                    f.write('::\n')
+                    f.write('\n.. code-block:: json\n\t:class: output\n')
                     for line in output.split('\n'):
                         f.write('\n\t{0}'.format(line))
                     f.write('\n')


### PR DESCRIPTION
Hi team.

Since the web-team added a new block to make outputs more appealing (https://github.com/wazuh/wazuh-documentation/pull/2084), we needed to update our `generate_rst.py` script in order to implement these new blocks.

Every **Example response** has this structure now:

```rst
**Example Response:**
.. code-block:: json
	:class: output
	{
	   "error": 0,
```

Regards.