### PR TITLE
Fix /cluster/:node_id/stats/remoted and /cluster/:node_id/stats/analysisd API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Now endpoint `GET /sca/:agent_id/checks/:policy_id` shows `condition` fields and can be used to filter by ([#4012](https://github.com/wazuh/wazuh/issues/4012))
 
+### Fixed
+- Fixed bug with API requests not being properly distributed to the selected node_id: ([#479](https://github.com/wazuh/wazuh-api/pull/479)).
+    * `GET /cluster/{node_id}/stats/analysisd` 
+    * `GET /cluster/{node_id}/stats/remoted`
+
 
 ## [v3.11.0]
 

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -365,7 +365,12 @@ router.get('/:node_id/stats/analysisd', cache(), function(req, res) {
     req.apicacheGroup = "cluster";
 
     var data_request = {'function': '/cluster/:node_id/stats/analysisd', 'arguments': {}};
-    
+
+    if (!filter.check(req.params, {'node_id':'names'}, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['node_id'] = req.params.node_id;
+
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 
@@ -374,7 +379,7 @@ router.get('/:node_id/stats/analysisd', cache(), function(req, res) {
  * @apiName GetManagerStatsRemotedCluster
  * @apiGroup Stats
  *
- * 
+ *
  * @apiDescription Returns a summary of the current remoted stats on the node.
  *
  * @apiExample {curl} Example usage*:
@@ -387,6 +392,12 @@ router.get('/:node_id/stats/remoted', cache(), function(req, res) {
     req.apicacheGroup = "cluster";
 
     var data_request = {'function': '/cluster/:node_id/stats/remoted', 'arguments': {}};
+
+    if (!filter.check(req.params, {'node_id':'names'}, req, res))  // Filter with error
+        return;
+
+    data_request['arguments']['node_id'] = req.params.node_id;
+
     execute.exec(python_bin, [wazuh_control], data_request, function (data) { res_h.send(req, res, data); });
 })
 

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -306,9 +306,9 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Analysisd stats', function (done) {
+        it('Analysisd stats (master)', function (done) {
             request(common.url)
-                .get("/cluster/:node_id/stats/analysisd")
+                .get("/cluster/master/stats/analysisd")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -336,9 +336,69 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Remoted stats', function (done) {
+        it('Analysisd stats (worker-1)', function (done) {
             request(common.url)
-                .get("/cluster/:node_id/stats/remoted")
+                .get("/cluster/worker-1/stats/analysisd")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['archives_queue_size', 'events_dropped',
+                                                          'rule_matching_queue_usage', 'alerts_queue_size',
+                                                          'event_queue_usage', 'events_edps', 'hostinfo_events_decoded',
+                                                          'syscollector_events_decoded', 'rootcheck_edps', 'events_processed',
+                                                          'firewall_queue_usage', 'alerts_queue_usage', 'firewall_queue_size',
+                                                          'alerts_written', 'firewall_written', 'syscheck_queue_size',
+                                                          'events_received', 'rootcheck_queue_usage', 'rootcheck_events_decoded',
+                                                          'rootcheck_queue_size', 'syscheck_edps', 'fts_written',
+                                                          'syscheck_queue_usage', 'other_events_edps', 'statistical_queue_usage',
+                                                          'hostinfo_edps', 'hostinfo_queue_usage', 'syscheck_events_decoded',
+                                                          'syscollector_queue_usage', 'archives_queue_usage', 'statistical_queue_size',
+                                                          'total_events_decoded', 'hostinfo_queue_size', 'syscollector_queue_size',
+                                                          'rule_matching_queue_size', 'other_events_decoded', 'event_queue_size',
+                                                          'syscollector_edps']);
+                    done();
+                });
+        });
+
+        it('Analysisd stats', function (done) {
+            request(common.url)
+                .get("/cluster/worker-2/stats/analysisd")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+                    res.body.data.should.have.properties(['archives_queue_size', 'events_dropped',
+                                                          'rule_matching_queue_usage', 'alerts_queue_size',
+                                                          'event_queue_usage', 'events_edps', 'hostinfo_events_decoded',
+                                                          'syscollector_events_decoded', 'rootcheck_edps', 'events_processed',
+                                                          'firewall_queue_usage', 'alerts_queue_usage', 'firewall_queue_size',
+                                                          'alerts_written', 'firewall_written', 'syscheck_queue_size',
+                                                          'events_received', 'rootcheck_queue_usage', 'rootcheck_events_decoded',
+                                                          'rootcheck_queue_size', 'syscheck_edps', 'fts_written',
+                                                          'syscheck_queue_usage', 'other_events_edps', 'statistical_queue_usage',
+                                                          'hostinfo_edps', 'hostinfo_queue_usage', 'syscheck_events_decoded',
+                                                          'syscollector_queue_usage', 'archives_queue_usage', 'statistical_queue_size',
+                                                          'total_events_decoded', 'hostinfo_queue_size', 'syscollector_queue_size',
+                                                          'rule_matching_queue_size', 'other_events_decoded', 'event_queue_size',
+                                                          'syscollector_edps']);
+                    done();
+                });
+        });
+
+        it('Remoted stats (master)', function (done) {
+            request(common.url)
+                .get("/cluster/master/stats/remoted")
                 .auth(common.credentials.user, common.credentials.password)
                 .expect("Content-type", /json/)
                 .expect(200)
@@ -356,7 +416,45 @@ describe('Cluster', function () {
                 });
         });
 
+        it('Remoted stats (worker-1)', function (done) {
+            request(common.url)
+                .get("/cluster/worker-1/stats/remoted")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
 
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['discarded_count', 'msg_sent', 'queue_size',
+                                                          'ctrl_msg_count', 'evt_count', 'tcp_sessions',
+                                                          'total_queue_size']);
+                    done();
+                });
+        });
+
+        it('Remoted stats (worker-2)', function (done) {
+            request(common.url)
+                .get("/cluster/worker-2/stats/remoted")
+                .auth(common.credentials.user, common.credentials.password)
+                .expect("Content-type", /json/)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) return done(err);
+
+                    res.body.should.have.properties(['error', 'data']);
+
+                    res.body.error.should.equal(0);
+
+                    res.body.data.should.have.properties(['discarded_count', 'msg_sent', 'queue_size',
+                                                          'ctrl_msg_count', 'evt_count', 'tcp_sessions',
+                                                          'total_queue_size']);
+                    done();
+                });
+        });
     });  // GET/cluster/stats
 
 

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -366,7 +366,7 @@ describe('Cluster', function () {
                 });
         });
 
-        it('Analysisd stats', function (done) {
+        it('Analysisd stats (worker-2)', function (done) {
             request(common.url)
                 .get("/cluster/worker-2/stats/analysisd")
                 .auth(common.credentials.user, common.credentials.password)


### PR DESCRIPTION
Hello team,

This PR closes https://github.com/wazuh/wazuh-api/issues/470.

It fixes API calls `GET /cluster/:node_id/stats/remoted` and `GET /cluster/:node_id/stats/analysisd` so the call is appropriately distributed to the cluster nodes.

### **Mocha test results:**
```
Cluster
    GET/cluster/nodes
(node:2755) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (265ms)
      ✓ Pagination (245ms)
      ✓ Retrieve all elements with limit=0 (252ms)
      ✓ Sort (249ms)
      ✓ Search (252ms)
      ✓ Select (251ms)
      ✓ Select 2 (253ms)
      ✓ Wrong select (255ms)
      ✓ Filters: type (263ms)
      ✓ Filters: query 1 (256ms)
      ✓ Filters: query 2 (256ms)
      ✓ Filters: invalid type (258ms)
    GET/cluster/:node_id/stats
      ✓ Cluster stats (249ms)
      ✓ Unexisting node stats (245ms)
      ✓ Analysisd stats (master) (249ms)
      ✓ Analysisd stats (worker-1) (251ms)
      ✓ Analysisd stats (257ms)
      ✓ Remoted stats (master) (250ms)
      ✓ Remoted stats (worker-1) (260ms)
      ✓ Remoted stats (worker-2) (251ms)
    GET/cluster/:node_id/logs
      ✓ Request (master) (266ms)
      ✓ Request (worker-1) (271ms)
      ✓ Request (worker-2) (269ms)
      ✓ Pagination (289ms)
      ✓ Sort (269ms)
      ✓ Search (263ms)
      ✓ Filters: type_log (261ms)
      ✓ Filters: category (253ms)
      ✓ Filters: query 1 (266ms)
      ✓ Filters: query 2 (273ms)
      ✓ Filters: query 3 (267ms)
      ✓ Filters: wrong query (78ms)
    GET/cluster/nodes/:node_name
      ✓ Request (258ms)
      ✓ Request wrong name (283ms)
    GET/cluster/status
      ✓ Request (255ms)
    GET/cluster/config
      ✓ Request (252ms)
    GET/cluster/healthcheck
      ✓ Request (288ms)
      ✓ Filter: node name (269ms)
    POST/cluster/:node_id/files
      ✓ Upload ossec.conf (master) (256ms)
      ✓ Upload ossec.conf (worker) (277ms)
      ✓ Upload new rules (268ms)
      ✓ Upload rules (overwrite=true) (261ms)
      ✓ Upload rules (overwrite=false) (253ms)
      ✓ Upload new decoder (247ms)
      ✓ Upload decoder (overwrite=true) (247ms)
      ✓ Upload decoder (without overwrite parameter) (271ms)
      ✓ Upload new list (266ms)
      ✓ Upload list (overwrite=true) (247ms)
      ✓ Upload list (overwrite=false) (259ms)
      ✓ Upload corrupted ossec.conf (master) (89ms)
      ✓ Upload corrupted ossec.conf (worker) (96ms)
      ✓ Upload malformed rules (83ms)
      ✓ Upload rules to unexisting node (261ms)
      ✓ Upload malformed decoder (80ms)
      ✓ Upload decoder to unexisting node (244ms)
      ✓ Upload malformed list (90ms)
      ✓ Upload list to unexisting node (286ms)
      ✓ Upload list with empty path (83ms)
      ✓ Upload a file with a wrong content type (87ms)
    GET/cluster/:node_id/files
      ✓ Request ossec.conf (master) (256ms)
      ✓ Request ossec.conf (worker) (263ms)
      ✓ Request rules (local) (251ms)
      ✓ Request rules (global) (250ms)
      ✓ Request decoders (local) (246ms)
      ✓ Request decoders (global) (242ms)
      ✓ Request lists (244ms)
      ✓ Request wrong path 1 (76ms)
      ✓ Request wrong path 2 (95ms)
      ✓ Request wrong path 3 (106ms)
      ✓ Request unexisting file (253ms)
      ✓ Request file from unexisting node (244ms)
      ✓ Request file with empty path (78ms)
      ✓ Request file with validation parameter (true) (265ms)
    GET/cluster/:node_id/configuration/validation (manager and worker OK)
      ✓ Request validation (master) (704ms)
      ✓ Request validation (worker) (693ms)
      ✓ Request validation (all nodes) (751ms)
    GET/cluster/:node_id/configuration/validation (manager KO, worker OK)
      ✓ Request validation (master) (245ms)
      ✓ Request validation (worker) (669ms)
      ✓ Request validation (all nodes) (716ms)
    GET/cluster/:node_id/configuration/validation (manager OK, worker KO)
      ✓ Request validation (master) (683ms)
      ✓ Request validation (worker) (257ms)
      ✓ Request validation (all nodes) (721ms)
    GET/cluster/:node_id/configuration/validation (manager and worker KO)
      ✓ Request validation (master) (252ms)
      ✓ Request validation (worker) (259ms)
      ✓ Request validation (all nodes) (262ms)
    DELETE/cluster/:node_id/files
      ✓ Delete rules (master) (244ms)
      ✓ Delete decoders (master) (242ms)
      ✓ Delete CDB list (master) (240ms)
      ✓ Delete file with empty path (77ms)
    GET/cluster/master/config/:component/:configuration
      ✓ Request-Agentless-Agentless (253ms)
      ✓ Request-Analysis-Global (253ms)
      ✓ Request-Analysis-Active-response (243ms)
      ✓ Request-Analysis-Alerts (251ms)
      ✓ Request-Analysis-Command (245ms)
      ✓ Request-Analysis-Internal (261ms)
      ✓ Request-Auth-Auth (267ms)
      ✓ Request-Com-Active-response (250ms)
      ✓ Request-Com-Internal (264ms)
      ✓ Request-Csyslog-Csyslog (249ms)
      ✓ Request-Integrator-Integration (243ms)
      ✓ Request-Logcollector-Localfile (247ms)
      ✓ Request-Logcollector-Socket (250ms)
      ✓ Request-Logcollector-Internal (252ms)
      ✓ Request-Mail-Global (246ms)
      ✓ Request-Mail-Alerts (245ms)
      ✓ Request-Mail-Internal (246ms)
      ✓ Request-Monitor-Internal (265ms)
      ✓ Request-Request-Remote (248ms)
      ✓ Request-Request-Internal (256ms)
      ✓ Request-Syscheck-Syscheck (246ms)
      ✓ Request-Syscheck-Rootcheck (249ms)
      ✓ Request-Syscheck-Internal (251ms)
      ✓ Request-Wmodules-Wmodules (270ms)
    PUT/cluster/:node_id/restart
      ✓ Request (worker) (253ms)
      ✓ Request (master) (257ms)


  115 passing (34s)
```