### PR TITLE
Increase filesize limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
     - `mitre`: Filters the rules by mitre requirement
     - `tsc`: Filters the rules by tsc requirement
 
+## [v3.13.0]
+
+- Increase the maximum allowed size of the files to be uploaded from 1MB to 10MB. This change applies to:
+    * `POST /manager/files` 
+    * `POST /cluster/:node_id/files` 
+    * `POST /agents/groups/:group_id/configuration` 
+    * `POST /agents/groups/:group_id/files/:file_name` 
+
 ## [v3.12.3]
 
 There are no changes for Wazuh API in this version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.13.0]
 
-- Increase the maximum allowed size of the files to be uploaded from 1MB to 10MB. This change applies to:
+- Increase the maximum allowed size of the files to be uploaded from 1MB to 10MB ([#487](https://github.com/wazuh/wazuh-api/pull/487)). This change applies to:
     * `POST /manager/files` 
     * `POST /cluster/:node_id/files` 
     * `POST /agents/groups/:group_id/configuration` 

--- a/app.js
+++ b/app.js
@@ -167,8 +167,8 @@ if (config.python) {
 // Body
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: true}));
-app.use(bodyParser.text({type:"application/xml", limit:"1mb"}));
-app.use(bodyParser.raw({type:"application/octet-stream", limit:"1mb"}));
+app.use(bodyParser.text({type:"application/xml", limit:"10mb"}));
+app.use(bodyParser.raw({type:"application/octet-stream", limit:"10mb"}));
 
 
 /**


### PR DESCRIPTION
Hi team,

This PR closes #486. In this PR, we have increase the maximun allowed size of the files to be uploaded from 1mb to 10mb. This change applies to:
- POST /manager/files
- POST /cluster/:node_id/files
- POST /agents/groups/:group_id/configuration
- POST /agents/groups/:group_id/files/:file_name

### File info
```bash
adriiiprodri@wazuh ls -l --block-size=M test.txt
-rw-r--r-- 1 adriiiprodri adriiiprodri 2M May 12 15:59 test.txt
```

### Before
```bash
adriiiprodri@wazuh curl -k -u foo:bar -X POST -H 'Content-type: application/octet-stream' --data-binary @test.txt "https://localhost:55000/manager/files?path=etc/lists/new-list&overwrite=true"
{"error":701,"message":"Size of XML file is too long"}
```

### After
```bash
adriiiprodri@wazuh curl -k -u foo:bar -X POST -H 'Content-type: application/octet-stream' --data-binary @test.txt "https://localhost:55000/manager/files?path=etc/lists/new-list&overwrite=true"
{"error":0,"data":"File updated successfully"}
```