### PR TITLE
Add new validator for some SCA input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.13.1]
 
+### Added
+
+- New filters in request `GET /sca/:agent_id/checks/:policy_id`:
+    * `reason`: Filters the SCA checks by 'reason' field ([#492](https://github.com/wazuh/wazuh-api/issues/492)).
+    * `status`: Filters the SCA checks by 'status' field ([#492](https://github.com/wazuh/wazuh-api/issues/492)).
+    * `command`: Filters the SCA checks by 'command' field ([#492](https://github.com/wazuh/wazuh-api/issues/492)).
+
+
 ## [v3.13.0]
 
 ### Added

--- a/controllers/security_configuration_assessment.js
+++ b/controllers/security_configuration_assessment.js
@@ -61,6 +61,9 @@ router.get('/:agent_id', cache(), function(req, res) {
  * @apiParam {Number} [limit=500] Maximum number of elements to return.
  * @apiParam {String} [sort] Sorts the collection by a field or fields (separated by comma). Use +/- at the beginning to list in ascending or descending order.
  * @apiParam {String} [search] Looks for elements with the specified string.
+ * @apiParam {String} [command] Looks for elements with the specified command.
+ * @apiParam {String} [status] Looks for elements with the specified status.
+ * @apiParam {String} [reason] Looks for elements with the specified reason.
  *
  * @apiDescription Returns the sca checks of an agent.
  *
@@ -69,11 +72,12 @@ router.get('/:agent_id', cache(), function(req, res) {
  *
  */
 router.get('/:agent_id/checks/:policy_id', cache(), function(req, res) {
-    query_checks = {'title': 'alphanumeric_param', 'description': 'alphanumeric_param',
-        'rationale': 'alphanumeric_param', 'remediation': 'alphanumeric_param',
+    query_checks = {'title': 'symbols_alphanumeric_param', 'description': 'symbols_alphanumeric_param',
+        'rationale': 'symbols_alphanumeric_param', 'remediation': 'symbols_alphanumeric_param',
         'file': 'paths', 'process': 'alphanumeric_param', 'directory': 'paths',
         'registry': 'alphanumeric_param', 'references': 'encoded_uri',
-        'result': 'alphanumeric_param', 'condition': 'alphanumeric_param'
+        'result': 'alphanumeric_param', 'condition': 'alphanumeric_param', 'command': 'alphanumeric_param',
+        'status': 'alphanumeric_param', 'reason': 'symbols_alphanumeric_param'
     };
     templates.array_request("/sca/:agent_id/checks/:policy_id", req, res,
                "sca",

--- a/helpers/input_validation.js
+++ b/helpers/input_validation.js
@@ -47,6 +47,10 @@ exports.alphanumeric_param = function(param) {
     return input_val(param, /^[a-zA-Z0-9_,\-\.\+\s\:]+$/);
 }
 
+exports.symbols_alphanumeric_param = function(param) {
+    return input_val(param, /^[a-zA-Z0-9_,<>!\-.+\s:\/()'"|=]+$/);
+}
+
 exports.sort_param = function(param) {
     return input_val(param, /^[a-zA-Z0-9_\-\,\s\+\.]+$/); // + is translated as \s
 }

--- a/test/test_sca.js
+++ b/test/test_sca.js
@@ -408,9 +408,71 @@ describe('SecurityConfigurationAssessment', function() {
             });
         });
 
+        it('Filters: title', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/cis_debian9_L2?&title=Ensure%20events%20that%20modify%20the%20system%27s%20Mandatory%20Access%20Controls%20are%20collected%20%28SELinux%29&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: incomplete title', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/cis_debian9_L2?title=Ensure%20events%20that&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.equal(0);
+                res.body.data.items.should.be.instanceof(Array);
+
+                done();
+            });
+
+        });
+
         it('Filters: description', function(done) {
             request(common.url)
             .get("/sca/000/checks/unix_audit?description=Turn%20on%20the%20auditd%20daemon%20to%20record%20system%20events.&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: rationale', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/cis_debian9_L2?rationale=In%20high%20security%20contexts%2C%20the%20risk%20of%20detecting%20unauthorized%20access%20or%20nonrepudiation%20exceeds%20the%20benefit%20of%20the%20system%27s%20availability.&limit=1")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)
@@ -495,6 +557,69 @@ describe('SecurityConfigurationAssessment', function() {
         it('Filters: result', function(done) {
             request(common.url)
             .get("/sca/000/checks/unix_audit?result=failed&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: command', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?command=systemctl%20is-enabled%20auditd&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: status', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/unix_audit?status=Not%20applicable&limit=1")
+            .auth(common.credentials.user, common.credentials.password)
+            .expect("Content-type",/json/)
+            .expect(200)
+            .end(function(err,res){
+                if (err) return done(err);
+
+                res.body.should.have.properties(['error', 'data']);
+
+                res.body.error.should.equal(0);
+                res.body.data.totalItems.should.be.above(0);
+                res.body.data.items.should.be.instanceof(Array);
+                res.body.data.items[0].should.have.properties(sca_check_fields);
+
+                done();
+            });
+
+        });
+
+        it('Filters: reason', function(done) {
+            request(common.url)
+            .get("/sca/000/checks/cis_debian9_L2?reason=Could%20not%20open%20file%20%27%2Fetc%2Fdefault%2Fgrub%27&limit=1")
             .auth(common.credentials.user, common.credentials.password)
             .expect("Content-type",/json/)
             .expect(200)


### PR DESCRIPTION
Hello team. This PR is related to [#5312 ](https://github.com/wazuh/wazuh/issues/5312)

# Description

In this PR a new validator (`symbols_alphanumeric_param`) is added. It allows to use most of the existing symbols within the `description`, `remediation`, `reason` and `title` fields of the `/sca/:agent_id/checks/:policy_id` endpoint. For example, searching for something like this is now allowed:

> Ensure events that modify the system's Mandatory Access Controls are collected (SELinux)

It is very important to escape all the single and double quotes in those places inside framework where a parameter like this is expected since otherwise, it could lead to security holes.

Some new fields can now be used in order to filter:
- reason
- status
- command

# Tests performed
## Mocha tests
```
mocha test_sca.js 


  SecurityConfigurationAssessment
    GET/sca/:agent_id
(node:2114) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
      ✓ Request (273ms)
      ✓ Pagination (313ms)
      ✓ Retrieve all elements with limit=0 (294ms)
      ✓ Sort (358ms)
      ✓ Search (263ms)
      ✓ Params: Bad agent id (89ms)
      ✓ Errors: No agent (310ms)
      ✓ Filters: Invalid filter (113ms)
      ✓ Filters: Invalid filter - Extra field (100ms)
      ✓ Filters: query (329ms)
      ✓ Filters: name (260ms)
      ✓ Filters: references (276ms)
      ✓ Retrieve all elements with limit=0 (312ms)
    GET/sca/:agent_id/checks/:policy_id
      ✓ Request (339ms)
      ✓ Pagination (346ms)
      ✓ Retrieve all elements with limit=0 (328ms)
      ✓ Sort (318ms)
      ✓ Search (375ms)
      ✓ Params: Bad agent id (94ms)
      ✓ Errors: No agent (291ms)
      ✓ Check not found (438ms)
      ✓ Retrieve all elements with limit=0 (311ms)
      ✓ Filters: title (307ms)
      ✓ Filters: incomplete title (320ms)
      ✓ Filters: description (287ms)
      ✓ Filters: rationale (321ms)
      ✓ Filters: remediation (303ms)
      ✓ Filters: file (286ms)
      ✓ Filters: references (254ms)
      ✓ Filters: result (256ms)
      ✓ Filters: command (244ms)
      ✓ Filters: status (249ms)
      ✓ Filters: reason (263ms)
      ✓ Filters: condition (261ms)


  34 passing (10s)
```

Best regards,
Selu.