### PR TITLE
Upgrade moment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v3.13.5]
+
+### Changed
+
+- Upgrade moment dependency to 2.29.3 ([#503](https://github.com/wazuh/wazuh-api/pull/503)).
+
 ## [v3.13.4]
 
 There are no changes for Wazuh API in this version.
@@ -33,15 +39,15 @@ There are no changes for Wazuh API in this version.
 
 - New filters in request `GET/rules`:
     - `mitre`: Filters the rules by mitre requirement
-    - `tsc`: Filters the rules by tsc requirement 
+    - `tsc`: Filters the rules by tsc requirement
 
 ### Changed
 
 - Increase the maximum allowed size of the files to be uploaded from 1MB to 10MB ([#487](https://github.com/wazuh/wazuh-api/pull/487)). This change applies to:
-    * `POST /manager/files` 
-    * `POST /cluster/:node_id/files` 
-    * `POST /agents/groups/:group_id/configuration` 
-    * `POST /agents/groups/:group_id/files/:file_name` 
+    * `POST /manager/files`
+    * `POST /cluster/:node_id/files`
+    * `POST /agents/groups/:group_id/configuration`
+    * `POST /agents/groups/:group_id/files/:file_name`
 
 ## [v3.12.3]
 
@@ -67,7 +73,7 @@ There are no changes for Wazuh API in this version.
 
 ### Fixed
 - Fixed bug with API requests not being properly distributed to the selected node_id: ([#479](https://github.com/wazuh/wazuh-api/pull/479)).
-    * `GET /cluster/{node_id}/stats/analysisd` 
+    * `GET /cluster/{node_id}/stats/analysisd`
     * `GET /cluster/{node_id}/stats/remoted`
 
 
@@ -106,8 +112,8 @@ There are no changes for Wazuh API in this version.
 
 ### Fixed
 - Fixed bug inserting duplicated agent without any errors ([#318](https://github.com/wazuh/wazuh-api/issues/318))
-- Fixed exception handling for `DELETE/agents` ([#441](https://github.com/wazuh/wazuh-api/pull/441)) 
-- Fixed API installation in Docker CentOS 7 containers ([#408](https://github.com/wazuh/wazuh-api/pull/408)) 
+- Fixed exception handling for `DELETE/agents` ([#441](https://github.com/wazuh/wazuh-api/pull/441))
+- Fixed API installation in Docker CentOS 7 containers ([#408](https://github.com/wazuh/wazuh-api/pull/408))
 - Deleted cache usage  in `POST/agents` ([#403](https://github.com/wazuh/wazuh-api/pull/403))
 
 ## [v3.9.0]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wazuh_api",
-  "version": "3.13.4",
-  "revision": "31304",
+  "version": "3.13.5",
+  "revision": "31305",
   "description": "Wazuh API.",
   "main": "app.js",
   "author": "Wazuh",
@@ -14,7 +14,7 @@
     "fast-xml-parser": "~3.12.11",
     "htpasswd": "~2.4.0",
     "http-auth": "~3.2.4",
-    "moment": "~2.24.0",
+    "moment": "~2.29.3",
     "rotating-file-stream": "~1.4.6",
     "uid-number": "~0.0.6"
   },


### PR DESCRIPTION
In this PR we have updated the version of "moment", here it can be seen that the new version "2.29.3" is fully functional:

```
[root@wazuh wazuh-api]# curl -k -u foo:bar "[https://localhost:55000?pretty](https://localhost:55000/?pretty)"
{
   "error": 0,
   "data": {
      "msg": "Welcome to Wazuh HIDS API",
      "api_version": "v3.13.5",
      "hostname": "860a89683b59",
      "timestamp": "Mon Jun 06 2022 13:55:52 GMT+0000 (UTC)"
   }
}

[root@wazuh wazuh-api]# head -n3 /var/ossec/api/node_modules/moment/package.json 
{
  "_from": "moment@~2.29.2",
  "_id": "moment@2.29.3",

[root@c7d8128c14e3 wazuh-api]# head /var/ossec/api/node_modules/moment/src/moment.js 
//! moment.js
//! version : 2.29.3
//! authors : Tim Wood, Iskren Chernev, Moment.js contributors
//! license : MIT
//! momentjs.com

import { hooks as moment, setHookCallback } from './lib/utils/hooks';

moment.version = '2.29.3';
```